### PR TITLE
Fixed ListenToSocketInternal so it works after Jellyfin 10.9.2

### DIFF
--- a/src/Rssdp/SsdpCommunicationsServer.cs
+++ b/src/Rssdp/SsdpCommunicationsServer.cs
@@ -416,19 +416,16 @@ namespace Rssdp.Infrastructure
                         var remoteEndpoint = (IPEndPoint)result.RemoteEndPoint;
                         var allBindInterfaces = _networkManager.GetAllBindInterfaces();
                         IPData localEndpointAdapter;
-                        if (
-                            allBindInterfaces.Count == 1
-                            && (
-                                allBindInterfaces.First().Address.Equals(IPAddress.Any)
-                                || allBindInterfaces.First().Address.Equals(IPAddress.IPv6Any)
-                            )
-                        )
+                        if (allBindInterfaces.Count == 1
+                            && (allBindInterfaces[0].Address.Equals(IPAddress.Any)
+                                || allBindInterfaces[0].Address.Equals(IPAddress.IPv6Any)))
                         {
-                            localEndpointAdapter = allBindInterfaces.First();
+                            localEndpointAdapter = allBindInterfaces[0];
                         } else
                         {
                             localEndpointAdapter = allBindInterfaces.First(a => a.Index == result.PacketInformation.Interface);
                         }
+
                         ProcessMessage(
                             Encoding.UTF8.GetString(receiveBuffer, 0, result.ReceivedBytes),
                             remoteEndpoint,
@@ -522,7 +519,7 @@ namespace Rssdp.Infrastructure
                 LocalIPAddress = localIPAddress
             });
         }
-        
+
         private Socket CreateSsdpUdpSocket(IPData bindInterface, int localPort)
         {
             var interfaceAddress = bindInterface.Address;
@@ -548,7 +545,7 @@ namespace Rssdp.Infrastructure
                 throw;
             }
         }
-        
+
         private Socket CreateUdpMulticastSocket(IPAddress multicastAddress, IPData bindInterface, int multicastTimeToLive, int localPort)
         {
             var bindIPAddress = bindInterface.Address;

--- a/src/Rssdp/SsdpCommunicationsServer.cs
+++ b/src/Rssdp/SsdpCommunicationsServer.cs
@@ -414,8 +414,21 @@ namespace Rssdp.Infrastructure
                     if (result.ReceivedBytes > 0)
                     {
                         var remoteEndpoint = (IPEndPoint)result.RemoteEndPoint;
-                        var localEndpointAdapter = _networkManager.GetAllBindInterfaces().First(a => a.Index == result.PacketInformation.Interface);
-
+                        var allBindInterfaces = _networkManager.GetAllBindInterfaces();
+                        IPData localEndpointAdapter;
+                        if (
+                            allBindInterfaces.Count == 1
+                            && (
+                                allBindInterfaces.First().Address.Equals(IPAddress.Any)
+                                || allBindInterfaces.First().Address.Equals(IPAddress.IPv6Any)
+                            )
+                        )
+                        {
+                            localEndpointAdapter = allBindInterfaces.First();
+                        } else
+                        {
+                            localEndpointAdapter = allBindInterfaces.First(a => a.Index == result.PacketInformation.Interface);
+                        }
                         ProcessMessage(
                             Encoding.UTF8.GetString(receiveBuffer, 0, result.ReceivedBytes),
                             remoteEndpoint,

--- a/src/Rssdp/SsdpCommunicationsServer.cs
+++ b/src/Rssdp/SsdpCommunicationsServer.cs
@@ -421,7 +421,8 @@ namespace Rssdp.Infrastructure
                                 || allBindInterfaces[0].Address.Equals(IPAddress.IPv6Any)))
                         {
                             localEndpointAdapter = allBindInterfaces[0];
-                        } else
+                        }
+                        else
                         {
                             localEndpointAdapter = allBindInterfaces.First(a => a.Index == result.PacketInformation.Interface);
                         }


### PR DESCRIPTION
Related to [this issue](https://github.com/jellyfin/jellyfin-plugin-dlna/issues/48).

The last Jellyfin update changed `NetworkManager`'s `GetAllBindInterfaces` method.
This caused `ListenToSocketInternal` to fail if no local addresses were set, because the new implementation returns an `IPData` object without setting its `Index` property.
This causes the `First()` method in `ListenToSocketInternal` to throw an `InvalidOperationException`.

To fix this I check if `GetAllBindInterfaces` returns one and just one `IPData` object and if this object corresponds to what `GetAllBindInterfaces` returns in case no local address has been set in Jellyfin.

Indeed `GetAllBindInterfaces` will only set those addresses (`IPAddress.Any` and `IPAddress.IPv6Any`) when no local address has been set.