### PR TITLE
Set publisher uri to http

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
+++ b/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
@@ -247,6 +247,8 @@ public sealed class DlnaHost : IHostedService, IDisposable
             .Where(x => x.AddressFamily != AddressFamily.InterNetworkV6)
             .ToList();
 
+        var httpBindPort = _appHost.HttpPort;
+
         if (validInterfaces.Count == 0)
         {
             // No interfaces returned, fall back to loopback
@@ -257,9 +259,11 @@ public sealed class DlnaHost : IHostedService, IDisposable
         {
             var fullService = "urn:schemas-upnp-org:device:MediaServer:1";
 
-            _logger.LogInformation("Registering publisher for {ResourceName} on {DeviceAddress}", fullService, intf.Address);
+            var uri = new UriBuilder(intf.Address + descriptorUri);
+            uri.Scheme = "http://";
+            uri.Port = httpBindPort;
 
-            var uri = new UriBuilder(_appHost.GetApiUrlForLocalAccess(intf.Address, false) + descriptorUri);
+            _logger.LogInformation("Registering publisher for {ResourceName} on {DeviceAddress} with uri {fulluri}", fullService, intf.Address, uri);
 
             var device = new SsdpRootDevice
             {

--- a/src/Jellyfin.Plugin.Dlna/Profiles/Xml/LG Smart TV.xml
+++ b/src/Jellyfin.Plugin.Dlna/Profiles/Xml/LG Smart TV.xml
@@ -3,7 +3,7 @@
   xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>LG Smart TV</Name>
   <Identification>
-    <FriendlyName>LG.*</FriendlyName>
+    <FriendlyName>LG*</FriendlyName>
     <Headers>
       <HttpHeaderInfo name="User-Agent" value="LG" match="Substring" />
     </Headers>


### PR DESCRIPTION
New plugin is not publishing the uri to proper http and port used in the Discovery.xml. Updated how the uri is built similar to how it was built when it was part of server core. Fixes #55 