### PR TITLE
Set publisher uri to http

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 name: "DLNA"
 guid: "33EBA9CD-7DA1-4720-967F-DD7DAE7B74A1"
 imageUrl: ""
-version: "1"
-targetAbi: "10.9.0.0"
+version: 2
+targetAbi: "10.9.2.0"
 framework: "net8.0"
 owner: "jellyfin"
 overview: "DLNA Service"
@@ -16,3 +16,8 @@ artifacts:
   - "Jellyfin.Plugin.Dlna.Playback.dll"
   - "Rssdp.dll"
 changelog: |-
+  - Fixed ListenToSocketInternal so it works after Jellyfin 10.9.2 (#51) @ms-afk
+
+  ### Dependency updates ###
+  - Update dependency Microsoft.AspNetCore.Authorization to v8.0.5 (#47) @renovate
+  - Update dependency Microsoft.AspNetCore.Authorization to v8.0.4 (#37) @renovate

--- a/src/Rssdp/SsdpCommunicationsServer.cs
+++ b/src/Rssdp/SsdpCommunicationsServer.cs
@@ -414,7 +414,18 @@ namespace Rssdp.Infrastructure
                     if (result.ReceivedBytes > 0)
                     {
                         var remoteEndpoint = (IPEndPoint)result.RemoteEndPoint;
-                        var localEndpointAdapter = _networkManager.GetAllBindInterfaces().First(a => a.Index == result.PacketInformation.Interface);
+                        var allBindInterfaces = _networkManager.GetAllBindInterfaces();
+                        IPData localEndpointAdapter;
+                        if (allBindInterfaces.Count == 1
+                            && (allBindInterfaces[0].Address.Equals(IPAddress.Any)
+                                || allBindInterfaces[0].Address.Equals(IPAddress.IPv6Any)))
+                        {
+                            localEndpointAdapter = allBindInterfaces[0];
+                        }
+                        else
+                        {
+                            localEndpointAdapter = allBindInterfaces.First(a => a.Index == result.PacketInformation.Interface);
+                        }
 
                         ProcessMessage(
                             Encoding.UTF8.GetString(receiveBuffer, 0, result.ReceivedBytes),
@@ -509,7 +520,7 @@ namespace Rssdp.Infrastructure
                 LocalIPAddress = localIPAddress
             });
         }
-        
+
         private Socket CreateSsdpUdpSocket(IPData bindInterface, int localPort)
         {
             var interfaceAddress = bindInterface.Address;
@@ -535,7 +546,7 @@ namespace Rssdp.Infrastructure
                 throw;
             }
         }
-        
+
         private Socket CreateUdpMulticastSocket(IPAddress multicastAddress, IPData bindInterface, int multicastTimeToLive, int localPort)
         {
             var bindIPAddress = bindInterface.Address;


### PR DESCRIPTION
Trying this again. 
New plugin is not publishing the uri to proper http and port used in the Discovery.xml. Updated how the uri is built similar to how it was built when it was part of server core. Fixes https://github.com/jellyfin/jellyfin-plugin-dlna/issues/55