### PR TITLE
restore video transcoding

### DIFF
--- a/src/Jellyfin.Plugin.Dlna.Playback/DynamicHlsHelper.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/DynamicHlsHelper.cs
@@ -106,7 +106,7 @@ public class DynamicHlsHelper
     /// <returns>A <see cref="Task"/> containing the resulting <see cref="ActionResult"/>.</returns>
     public async Task<ActionResult> GetMasterHlsPlaylist(
         TranscodingJobType transcodingJobType,
-        DlnaStreamingRequestDto streamingRequest,
+        StreamingRequestDto streamingRequest,
         bool enableAdaptiveBitrateStreaming)
     {
         var isHeadRequest = _httpContextAccessor.HttpContext?.Request.Method == WebRequestMethods.Http.Head;
@@ -121,7 +121,7 @@ public class DynamicHlsHelper
     }
 
     private async Task<ActionResult> GetMasterPlaylistInternal(
-        DlnaStreamingRequestDto streamingRequest,
+        StreamingRequestDto streamingRequest,
         bool isHeadRequest,
         bool enableAdaptiveBitrateStreaming,
         TranscodingJobType transcodingJobType,

--- a/src/Jellyfin.Plugin.Dlna.Playback/Model/DlnaVideoRequestDto.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/Model/DlnaVideoRequestDto.cs
@@ -1,23 +1,14 @@
+using MediaBrowser.Controller.Streaming;
+
 namespace Jellyfin.Plugin.Dlna.Playback.Model;
 
 /// <summary>
 /// The video request dto.
 /// </summary>
-public class DlnaVideoRequestDto : DlnaStreamingRequestDto
+public class DlnaVideoRequestDto : VideoRequestDto
 {
     /// <summary>
-    /// Gets a value indicating whether this instance has fixed resolution.
+    /// Gets or sets the device profile.
     /// </summary>
-    /// <value><c>true</c> if this instance has fixed resolution; otherwise, <c>false</c>.</value>
-    public bool HasFixedResolution => Width.HasValue || Height.HasValue;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether to enable subtitles in the manifest.
-    /// </summary>
-    public bool EnableSubtitlesInManifest { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether to enable trickplay images.
-    /// </summary>
-    public bool EnableTrickplay { get; set; }
+    public string? DeviceProfileId { get; set; }
 }


### PR DESCRIPTION
As far as I see at the moment, whenever the direct streaming is not possible, the resulting ffmpeg command produces an audio-only stream (`-vn` argument disables video).

The main issue is that jellyfin's [StreamState](https://github.com/jellyfin/jellyfin/blob/ffecdfc18cbe4e97f6812f00ee97364c99fc5726/MediaBrowser.Controller/Streaming/StreamState.cs#L51) doesn't consider `DlnaVideoRequestDto` to be a video request due to `DlnaVideoRequestDto` not being inherited from `VideoRequestDto`. Therefore `StreamState.IsVideoRequest` is always false, and it wreaks the logic in many places.
As a result, all video requests are being processed as audio only.

This commit updates dlna video requests to inherit from `VideoRequestDto` directly and adds `DeviceProfileId` (which is the only extra property) from `DlnaStreamingRequestDto`.

The approach may be not that great, but this way it doesn't require changes in jellyfin itself.

The patch should fix #65.