### PR TITLE
Standardize bind IPs in ssdp and dlnahost

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 name: "DLNA"
 guid: "33EBA9CD-7DA1-4720-967F-DD7DAE7B74A1"
 imageUrl: ""
-version: "1"
-targetAbi: "10.9.0.0"
+version: 2
+targetAbi: "10.9.2.0"
 framework: "net8.0"
 owner: "jellyfin"
 overview: "DLNA Service"
@@ -16,3 +16,8 @@ artifacts:
   - "Jellyfin.Plugin.Dlna.Playback.dll"
   - "Rssdp.dll"
 changelog: |-
+  - Fixed ListenToSocketInternal so it works after Jellyfin 10.9.2 (#51) @ms-afk
+
+  ### Dependency updates ###
+  - Update dependency Microsoft.AspNetCore.Authorization to v8.0.5 (#47) @renovate
+  - Update dependency Microsoft.AspNetCore.Authorization to v8.0.4 (#37) @renovate

--- a/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
+++ b/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading;
@@ -243,8 +244,12 @@ public sealed class DlnaHost : IHostedService, IDisposable
 
         // Only get bind addresses in LAN
         // IPv6 is currently unsupported
-        var validInterfaces = _networkManager.GetInternalBindAddresses()
+        var validInterfaces =  _networkManager.GetInternalBindAddresses()
+            .Where(x => x.Address is not null)
             .Where(x => x.AddressFamily != AddressFamily.InterNetworkV6)
+            .Where(x => x.AddressFamily == AddressFamily.InterNetwork)
+            .Where(x => x.SupportsMulticast)
+            .Where(x => !x.Address.Equals(IPAddress.Loopback))
             .ToList();
 
         var httpBindPort = _appHost.HttpPort;

--- a/src/Rssdp/SsdpCommunicationsServer.cs
+++ b/src/Rssdp/SsdpCommunicationsServer.cs
@@ -414,7 +414,18 @@ namespace Rssdp.Infrastructure
                     if (result.ReceivedBytes > 0)
                     {
                         var remoteEndpoint = (IPEndPoint)result.RemoteEndPoint;
-                        var localEndpointAdapter = _networkManager.GetAllBindInterfaces().First(a => a.Index == result.PacketInformation.Interface);
+                        var allBindInterfaces = _networkManager.GetAllBindInterfaces();
+                        IPData localEndpointAdapter;
+                        if (allBindInterfaces.Count == 1
+                            && (allBindInterfaces[0].Address.Equals(IPAddress.Any)
+                                || allBindInterfaces[0].Address.Equals(IPAddress.IPv6Any)))
+                        {
+                            localEndpointAdapter = allBindInterfaces[0];
+                        }
+                        else
+                        {
+                            localEndpointAdapter = allBindInterfaces.First(a => a.Index == result.PacketInformation.Interface);
+                        }
 
                         ProcessMessage(
                             Encoding.UTF8.GetString(receiveBuffer, 0, result.ReceivedBytes),
@@ -509,7 +520,7 @@ namespace Rssdp.Infrastructure
                 LocalIPAddress = localIPAddress
             });
         }
-        
+
         private Socket CreateSsdpUdpSocket(IPData bindInterface, int localPort)
         {
             var interfaceAddress = bindInterface.Address;
@@ -535,7 +546,7 @@ namespace Rssdp.Infrastructure
                 throw;
             }
         }
-        
+
         private Socket CreateUdpMulticastSocket(IPAddress multicastAddress, IPData bindInterface, int multicastTimeToLive, int localPort)
         {
             var bindIPAddress = bindInterface.Address;

--- a/src/Rssdp/SsdpCommunicationsServer.cs
+++ b/src/Rssdp/SsdpCommunicationsServer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -233,6 +234,18 @@ namespace Rssdp.Infrastructure
             }
         }
 
+        public List<IPAddress> GetBindIPs()
+        {
+            List<IPAddress> iplist = new List<IPAddress>();
+            iplist = (List<IPAddress>)_networkManager.GetInternalBindAddresses()
+                .Where(x => x.Address is not null)
+                .Where(x => x.SupportsMulticast)
+                .Where(x => x.AddressFamily == AddressFamily.InterNetwork)
+                .Where(x => !x.Address.Equals(IPAddress.Loopback));
+
+            return iplist;
+        }
+
         public Task SendMulticastMessage(string message, IPAddress fromlocalIPAddress, CancellationToken cancellationToken)
         {
             return SendMulticastMessage(message, SsdpConstants.UdpResendCount, fromlocalIPAddress, cancellationToken);
@@ -343,24 +356,19 @@ namespace Rssdp.Infrastructure
             var sockets = new List<Socket>();
             var multicastGroupAddress = IPAddress.Parse(SsdpConstants.MulticastLocalAdminAddress);
 
-            // IPv6 is currently unsupported
-            var validInterfaces = _networkManager.GetInternalBindAddresses()
-                .Where(x => x.Address is not null)
-                .Where(x => x.SupportsMulticast)
-                .Where(x => x.AddressFamily == AddressFamily.InterNetwork)
-                .DistinctBy(x => x.Index);
+            var validInterfaces = GetBindIPs();
 
             foreach (var intf in validInterfaces)
             {
                 try
                 {
-                    var socket = CreateUdpMulticastSocket(multicastGroupAddress, intf, _MulticastTtl, SsdpConstants.MulticastPort);
-                    _ = ListenToSocketInternal(socket);
+                    var socket = CreateUdpMulticastSocket(multicastGroupAddress, intf.GetAddressBytes, _MulticastTtl, SsdpConstants.MulticastPort);
+                    _ = ListenToSocketInternal(socket, intf.GetAddressBytes);
                     sockets.Add(socket);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Failed to create SSDP UDP multicast socket for {0} on interface {1} (index {2})", intf.Address, intf.Name, intf.Index);
+                    _logger.LogError(ex, "Failed to create SSDP UDP multicast socket for {0} on interface {1} (index {2})", intf.GetAddressBytes, intf.Name, intf.Index);
                 }
             }
 
@@ -372,35 +380,26 @@ namespace Rssdp.Infrastructure
             var sockets = new List<Socket>();
 
             // IPv6 is currently unsupported
-            var validInterfaces = _networkManager.GetInternalBindAddresses()
-                .Where(x => x.Address is not null)
-                .Where(x => x.SupportsMulticast)
-                .Where(x => x.AddressFamily == AddressFamily.InterNetwork);
-
-            if (OperatingSystem.IsMacOS())
-            {
-                // Manually remove loopback on macOS due to https://github.com/dotnet/runtime/issues/24340
-                validInterfaces = validInterfaces.Where(x => !x.Address.Equals(IPAddress.Loopback));
-            }
+            var validInterfaces = GetBindIPs();
 
             foreach (var intf in validInterfaces)
             {
                 try
                 {
-                    var socket = CreateSsdpUdpSocket(intf, _LocalPort);
-                    _ = ListenToSocketInternal(socket);
+                    var socket = CreateSsdpUdpSocket(intf.GetAddressBytes, _LocalPort);
+                    _ = ListenToSocketInternal(socket, intf.GetAddressBytes);
                     sockets.Add(socket);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Failed to create SSDP UDP sender socket for {0} on interface {1} (index {2})", intf.Address, intf.Name, intf.Index);
+                    _logger.LogError(ex, "Failed to create SSDP UDP sender socket for {0} on interface {1} (index {2})", intf.GetAddressBytes, intf.Name, intf.Index);
                 }
             }
 
             return sockets;
         }
 
-        private async Task ListenToSocketInternal(Socket socket)
+        private async Task ListenToSocketInternal(Socket socket, IPData listenIP)
         {
             var cancelled = false;
             var receiveBuffer = new byte[8192];
@@ -414,23 +413,11 @@ namespace Rssdp.Infrastructure
                     if (result.ReceivedBytes > 0)
                     {
                         var remoteEndpoint = (IPEndPoint)result.RemoteEndPoint;
-                        var allBindInterfaces = _networkManager.GetAllBindInterfaces();
-                        IPData localEndpointAdapter;
-                        if (allBindInterfaces.Count == 1
-                            && (allBindInterfaces[0].Address.Equals(IPAddress.Any)
-                                || allBindInterfaces[0].Address.Equals(IPAddress.IPv6Any)))
-                        {
-                            localEndpointAdapter = allBindInterfaces[0];
-                        }
-                        else
-                        {
-                            localEndpointAdapter = allBindInterfaces.First(a => a.Index == result.PacketInformation.Interface);
-                        }
 
                         ProcessMessage(
                             Encoding.UTF8.GetString(receiveBuffer, 0, result.ReceivedBytes),
                             remoteEndpoint,
-                            localEndpointAdapter.Address);
+                            listenIP.Address);
                     }
                 }
                 catch (ObjectDisposedException)


### PR DESCRIPTION
The reported problem was that the plugin was not responding to ssdp:discover messages. After looking at this for a bit I found the plugin was using different ways for how the networking IPs were selected, in both the ssdp and the dlnahost.  There was also a spot where, from what I understood, the bind IPs list was being looped through and listed twice. I'll admit I don't fully understand the UPNP spec yet, but it didn't make sense to have multiple criteria for how the adapters were being selected. This pr aligns both ssdp and dlnahost to build that list the same way. I think there is still some more work to do to refine the description.xml but myself and a few others in the thread listed below have tested this and are now seeing JF listed on their dlna browsers and report that the plugin is now responding properly to ssdp:discover messages. 
Fixes https://github.com/jellyfin/jellyfin-plugin-dlna/issues/64