### PR TITLE
Fix Bigscreen compatibility issues

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
+++ b/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
@@ -66,7 +66,7 @@ public class DlnaServerController : ControllerBase
     {
         var useRelativePath = false;
         string? userAgent = Request.Headers.UserAgent;
-        if (userAgent != null)
+        if (userAgent is not null)
         {
             userAgent = userAgent.Substring(0, userAgent.IndexOf('/'));
             foreach (var relativePathUserAgent in relativeUrlUserAgents)

--- a/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
+++ b/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
@@ -69,14 +69,7 @@ public class DlnaServerController : ControllerBase
         if (userAgent is not null)
         {
             userAgent = userAgent.Substring(0, userAgent.IndexOf('/'));
-            foreach (var relativePathUserAgent in relativeUrlUserAgents)
-            { 
-                if (userAgent == relativePathUserAgent)
-                {
-                    useRelativePath = true;
-                    break;
-                }
-            }
+            useRelativePath = relativeUrlUserAgents.Contains(userAgent, StringComparison.Ordinal);
         }
 
         var url = useRelativePath ? GetRelativeUrl() : GetAbsoluteUri();

--- a/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
+++ b/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
@@ -22,7 +22,7 @@ namespace Jellyfin.Plugin.Dlna.Api;
 [Authorize(Policy = Policies.AnonymousLanAccessPolicy)]
 public class DlnaServerController : ControllerBase
 {
-    private static readonly string[] _relativeUrlUserAgents = { "Bigscreen" };
+    private static readonly string[] _relativePathUserAgents = { "Bigscreen" };
 
     private readonly IDlnaManager _dlnaManager;
     private readonly IContentDirectory _contentDirectory;
@@ -67,7 +67,7 @@ public class DlnaServerController : ControllerBase
         if (userAgent is not null)
         {
             userAgent = userAgent.Substring(0, userAgent.IndexOf('/'));
-            useRelativePath = _relativeUrlUserAgents.Contains(userAgent, StringComparison.Ordinal);
+            useRelativePath = _relativePathUserAgents.Contains(userAgent, StringComparison.Ordinal);
         }
 
         var url = useRelativePath ? GetRelativeUrl() : GetAbsoluteUri();

--- a/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
+++ b/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
@@ -22,6 +22,8 @@ namespace Jellyfin.Plugin.Dlna.Api;
 [Authorize(Policy = Policies.AnonymousLanAccessPolicy)]
 public class DlnaServerController : ControllerBase
 {
+    private static readonly string[] _relativeUrlUserAgents = { "Bigscreen" };
+
     private readonly IDlnaManager _dlnaManager;
     private readonly IContentDirectory _contentDirectory;
     private readonly IConnectionManager _connectionManager;
@@ -46,10 +48,6 @@ public class DlnaServerController : ControllerBase
         _mediaReceiverRegistrar = mediaReceiverRegistrar;
     }
 
-    private static readonly string[] relativeUrlUserAgents = new string[] {
-        "Bigscreen"
-    };
-
     /// <summary>
     /// Get Description Xml.
     /// </summary>
@@ -69,7 +67,7 @@ public class DlnaServerController : ControllerBase
         if (userAgent is not null)
         {
             userAgent = userAgent.Substring(0, userAgent.IndexOf('/'));
-            useRelativePath = relativeUrlUserAgents.Contains(userAgent, StringComparison.Ordinal);
+            useRelativePath = _relativeUrlUserAgents.Contains(userAgent, StringComparison.Ordinal);
         }
 
         var url = useRelativePath ? GetRelativeUrl() : GetAbsoluteUri();

--- a/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
+++ b/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
@@ -59,7 +59,7 @@ public class DlnaServerController : ControllerBase
     [Produces(MediaTypeNames.Text.Xml)]
     public ActionResult<string> GetDescriptionXml([FromRoute, Required] string serverId)
     {
-        var url = GetAbsoluteUri();
+        var url = GetRelativeUrl();
         var serverAddress = url.Substring(0, url.IndexOf("/dlna/", StringComparison.OrdinalIgnoreCase));
         var xml = _dlnaManager.GetServerDescriptionXml(Request.Headers, serverId, serverAddress);
         return Ok(xml);
@@ -277,6 +277,11 @@ public class DlnaServerController : ControllerBase
     private string GetAbsoluteUri()
     {
         return $"{Request.Scheme}://{Request.Host}{Request.PathBase}{Request.Path}";
+    }
+
+    private string GetRelativeUrl()
+    {
+        return $"{Request.PathBase}{Request.Path}";
     }
 
     private Task<ControlResponse> ProcessControlRequestInternalAsync(string id, Stream requestStream, IUpnpService service)

--- a/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
+++ b/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
@@ -70,7 +70,7 @@ public class DlnaServerController : ControllerBase
             useRelativePath = _relativePathUserAgents.Contains(userAgent, StringComparison.Ordinal);
         }
 
-        var url = useRelativePath ? GetRelativeUrl() : GetAbsoluteUri();
+        var url = useRelativePath ? GetRelativePath() : GetAbsoluteUri();
         var serverAddress = url.Substring(0, url.IndexOf("/dlna/", StringComparison.OrdinalIgnoreCase));
         var xml = _dlnaManager.GetServerDescriptionXml(Request.Headers, serverId, serverAddress);
         return Ok(xml);
@@ -290,7 +290,7 @@ public class DlnaServerController : ControllerBase
         return $"{Request.Scheme}://{Request.Host}{Request.PathBase}{Request.Path}";
     }
 
-    private string GetRelativeUrl()
+    private string GetRelativePath()
     {
         return $"{Request.PathBase}{Request.Path}";
     }

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -1003,7 +1003,7 @@ public class ControlHandler : BaseControlHandler
 
         if (query.StartIndex > 0)
         {
-            limit = (query.Limit == null || query.Limit <= 0) ? int.MaxValue : (query.StartIndex + query.Limit).Value;
+            limit = (query.Limit is null || query.Limit <= 0) ? int.MaxValue : (query.StartIndex + query.Limit).Value;
         }
         else
         {

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -681,15 +681,7 @@ public class ControlHandler : BaseControlHandler
             new(item, StubType.FavoriteSongs)
         };
 
-        if (limit < serverItems.Length)
-        {
-            serverItems = serverItems[..limit.Value];
-        }
-
-        return new QueryResult<ServerItem>(
-            startIndex,
-            serverItems.Length,
-            serverItems);
+        return GetTrimmedArray(serverItems, startIndex, limit);
     }
 
     /// <summary>
@@ -737,15 +729,7 @@ public class ControlHandler : BaseControlHandler
             new(item, StubType.Genres)
         };
 
-        if (limit < array.Length)
-        {
-            array = array[..limit.Value];
-        }
-
-        return new QueryResult<ServerItem>(
-            startIndex,
-            array.Length,
-            array);
+        return GetTrimmedArray(array, startIndex, limit);
     }
 
     /// <summary>
@@ -821,15 +805,7 @@ public class ControlHandler : BaseControlHandler
             new(item, StubType.Genres)
         };
 
-        if (limit < serverItems.Length)
-        {
-            serverItems = serverItems[..limit.Value];
-        }
-
-        return new QueryResult<ServerItem>(
-            startIndex,
-            serverItems.Length,
-            serverItems);
+        return GetTrimmedArray(serverItems, startIndex, limit);
     }
 
     /// <summary>
@@ -1121,6 +1097,34 @@ public class ControlHandler : BaseControlHandler
         var result = _libraryManager.GetItemsResult(query);
 
         return ToResult(startIndex, result);
+    }
+    
+    private static QueryResult<ServerItem> GetTrimmedArray(ServerItem[] serverItems, int? startIndex, int? limit)
+    {
+        if (startIndex >= serverItems.Length)
+        {
+            serverItems = new ServerItem[] { };
+
+            return new QueryResult<ServerItem>(
+                startIndex,
+                serverItems.Length,
+                serverItems);
+        }
+
+        if (startIndex > 0)
+        {
+            serverItems = serverItems[startIndex.Value..];
+        }
+
+        if (limit < serverItems.Length)
+        {
+            serverItems = serverItems[..limit.Value];
+        }
+
+        return new QueryResult<ServerItem>(
+            startIndex,
+            serverItems.Length,
+            serverItems);
     }
 
     /// <summary>

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -1260,12 +1260,12 @@ public class ControlHandler : BaseControlHandler
     }
 
     /// <summary>
-    /// Discards elements before startIndex and elements after startIndex+limit from an array of serverItems.
+    /// Discards elements before startIndex and elements after startIndex+limit from an array of <see cref="ServerItem"/>.
     /// </summary>
-    /// <param name="serverItems"></param>
-    /// <param name="startIndex"></param>
-    /// <param name="limit"></param>
-    /// <returns></returns>
+    /// <param name="serverItems">An array of <see cref="ServerItem"/>.</param>
+    /// <param name="startIndex">The start index.</param>
+    /// <param name="limit">The maximum number to return.</param>
+    /// <returns>The corresponding trimmed array of <see cref="ServerItem"/></returns>
     private static ServerItem[] GetTrimmedServerItemsArray(ServerItem[] serverItems, int? startIndex, int? limit)
     {
         if (startIndex >= serverItems.Length)

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -1040,9 +1040,9 @@ public class ControlHandler : BaseControlHandler
             {
                 items = Array.Empty<BaseItem>();
             }
-            else if (query.Limit > 0 && items.Length > query.Limit.Value)
+            else if (query.Limit > 0 && items.Length > limit)
             {
-                items = items[query.StartIndex.Value..(query.StartIndex + query.Limit).Value];
+                items = items[query.StartIndex.Value..(query.StartIndex + query.Limit - 1).Value];
             }
             else
             {

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -681,7 +681,11 @@ public class ControlHandler : BaseControlHandler
             new(item, StubType.FavoriteSongs)
         };
 
-        return GetTrimmedArray(serverItems, startIndex, limit);
+        serverItems = GetTrimmedServerItemsArray(serverItems, startIndex, limit);
+        return new QueryResult<ServerItem>(
+            startIndex,
+            serverItems.Length,
+            serverItems);
     }
 
     /// <summary>
@@ -729,7 +733,11 @@ public class ControlHandler : BaseControlHandler
             new(item, StubType.Genres)
         };
 
-        return GetTrimmedArray(array, startIndex, limit);
+        array = GetTrimmedServerItemsArray(array, startIndex, limit);
+        return new QueryResult<ServerItem>(
+            startIndex,
+            array.Length,
+            array);
     }
 
     /// <summary>
@@ -805,7 +813,11 @@ public class ControlHandler : BaseControlHandler
             new(item, StubType.Genres)
         };
 
-        return GetTrimmedArray(serverItems, startIndex, limit);
+        serverItems = GetTrimmedServerItemsArray(serverItems, startIndex, limit);
+        return new QueryResult<ServerItem>(
+            startIndex,
+            serverItems.Length,
+            serverItems);
     }
 
     /// <summary>
@@ -1026,7 +1038,7 @@ public class ControlHandler : BaseControlHandler
         {
             if (items.Length <= query.StartIndex)
             {
-                items = new BaseItem[] { };
+                items = Array.Empty<BaseItem>();
             }
             else if (query.Limit > 0 && items.Length > query.Limit.Value)
             {
@@ -1124,34 +1136,6 @@ public class ControlHandler : BaseControlHandler
         var result = _libraryManager.GetItemsResult(query);
 
         return ToResult(startIndex, result);
-    }
-    
-    private static QueryResult<ServerItem> GetTrimmedArray(ServerItem[] serverItems, int? startIndex, int? limit)
-    {
-        if (startIndex >= serverItems.Length)
-        {
-            serverItems = new ServerItem[] { };
-
-            return new QueryResult<ServerItem>(
-                startIndex,
-                serverItems.Length,
-                serverItems);
-        }
-
-        if (startIndex > 0)
-        {
-            serverItems = serverItems[startIndex.Value..];
-        }
-
-        if (limit < serverItems.Length)
-        {
-            serverItems = serverItems[..limit.Value];
-        }
-
-        return new QueryResult<ServerItem>(
-            startIndex,
-            serverItems.Length,
-            serverItems);
     }
 
     /// <summary>
@@ -1273,5 +1257,32 @@ public class ControlHandler : BaseControlHandler
         Logger.LogError("Error parsing item Id: {Id}. Returning user root folder.", id);
 
         return new ServerItem(_libraryManager.GetUserRootFolder(), null);
+    }
+
+    /// <summary>
+    /// Discards elements before startIndex and elements after startIndex+limit from an array of serverItems.
+    /// </summary>
+    /// <param name="serverItems"></param>
+    /// <param name="startIndex"></param>
+    /// <param name="limit"></param>
+    /// <returns></returns>
+    private static ServerItem[] GetTrimmedServerItemsArray(ServerItem[] serverItems, int? startIndex, int? limit)
+    {
+        if (startIndex >= serverItems.Length)
+        {
+            return Array.Empty<ServerItem>();
+        }
+
+        if (startIndex > 0)
+        {
+            serverItems = serverItems[startIndex.Value..];
+        }
+
+        if (limit < serverItems.Length)
+        {
+            serverItems = serverItems[..limit.Value];
+        }
+
+        return serverItems;
     }
 }

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -1015,7 +1015,7 @@ public class ControlHandler : BaseControlHandler
 
         if (query.StartIndex > 0)
         {
-            limit = (query.Limit is null || query.Limit <= 0) ? int.MaxValue : (query.StartIndex + query.Limit).Value;
+            limit = (query.Limit <= 0) ? int.MaxValue : (query.StartIndex.Value + (query.Limit ?? 50));
         }
         else
         {

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -1027,7 +1027,7 @@ public class ControlHandler : BaseControlHandler
             {
                 // User cannot be null here as the caller has set it
                 User = query.User!,
-                Limit = query.Limit ?? 50,
+                Limit = limit,
                 IncludeItemTypes = new[] { itemType },
                 ParentId = parent?.Id ?? Guid.Empty,
                 GroupItems = true

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -1036,18 +1036,7 @@ public class ControlHandler : BaseControlHandler
 
         if (query.StartIndex > 0)
         {
-            if (items.Length <= query.StartIndex)
-            {
-                items = Array.Empty<BaseItem>();
-            }
-            else if (query.Limit > 0 && items.Length > limit)
-            {
-                items = items[query.StartIndex.Value..(query.StartIndex + query.Limit - 1).Value];
-            }
-            else
-            {
-                items = items[query.StartIndex.Value..];
-            }
+            items = (items.Length <= query.StartIndex) ? Array.Empty<BaseItem>() : items[query.StartIndex.Value..];
         }
 
         return ToResult(query.StartIndex, items);

--- a/src/Jellyfin.Plugin.Dlna/Server/DescriptionXmlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Server/DescriptionXmlBuilder.cs
@@ -23,7 +23,6 @@ public class DescriptionXmlBuilder
     public DescriptionXmlBuilder(DlnaDeviceProfile profile, string serverUdn, string serverAddress, string serverName, string serverId)
     {
         ArgumentException.ThrowIfNullOrEmpty(serverUdn);
-        ArgumentException.ThrowIfNullOrEmpty(serverAddress);
 
         _profile = profile;
         _serverUdn = serverUdn;


### PR DESCRIPTION
The ['Bigscreen Beta' app](https://www.meta.com/en-gb/experiences/bigscreen-beta/2497738113633933) for Quest doesn't work with absolute URIs in `description.xml`: instead of querying `http://<...>` it makes a `GET /ttp://<...>` request. This PR makes it so that service URIs in `description.xml` are switched to relative paths if the request user-agent is set to `Bigscreen/<any version>`.

Additionally, Bigscreen attempts to build a list of library items by loading blocks of items, 10000 at a time, incrementing the start index and waiting for an empty block to stop attempting to load more items. The plugin currently has a bug where querying library folders returns all of the stub folders regardless of the requested start index, making Bigscreen enter an infinite loop upon entering any library folder. This PR fixes this bug.

The same behavior can be triggered by entering 'Latest'-type folders. This is because (1) no start index is passed to Jellyfin in `LatestItemsQuery` and (2) Jellyfin is currently ignoring start index in `LatestItemsQuery` anyway. Since, according to API docs, `GET /Items/Latest` doesn't have a `startIndex` query parameter, it appears to me that this behavior is intentional. This PR thus fixes this bug by making the plugin request up to `StartIndex+Limit` latest items and then trim the excess, when provided with a non-zero start index. If the start index is non-zero but the limit is null, or less than or equal to zero, the plugin requests up to `int.MaxValue` items. Otherwise, the behavior stays the same.

Maybe the maximum amount of latest items that can be requested should be limited. Though, even without a limit, many unlikely conditions will have to be met for this to result in a hit to performance that is even remotely observable: many library items, many very specific clients querying the server, specifically the 'Latest' folders, over DLNA (which is local), at the same time.

Fixes: #81