### PR TITLE
fix: add the icons to the compiled resources (#109)

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/Jellyfin.Plugin.Dlna.csproj
+++ b/src/Jellyfin.Plugin.Dlna/Jellyfin.Plugin.Dlna.csproj
@@ -18,6 +18,8 @@
     <ItemGroup>
       <EmbeddedResource Include="Configuration\config.html" />
       <EmbeddedResource Include="Configuration\config.js" />
+      <EmbeddedResource Include="Images\*.jpg" />      
+      <EmbeddedResource Include="Images\*.png" />
       <EmbeddedResource Include="Profiles\Xml\*.xml" />
     </ItemGroup>
 </Project>

--- a/src/Jellyfin.Plugin.Dlna/Jellyfin.Plugin.Dlna.csproj
+++ b/src/Jellyfin.Plugin.Dlna/Jellyfin.Plugin.Dlna.csproj
@@ -18,7 +18,7 @@
     <ItemGroup>
       <EmbeddedResource Include="Configuration\config.html" />
       <EmbeddedResource Include="Configuration\config.js" />
-      <EmbeddedResource Include="Images\*.jpg" />      
+      <EmbeddedResource Include="Images\*.jpg" />
       <EmbeddedResource Include="Images\*.png" />
       <EmbeddedResource Include="Profiles\Xml\*.xml" />
     </ItemGroup>


### PR DESCRIPTION
This fix solves the reported 404 error and the Jellyfin icon is now correctly displayed as icon for that DLNA instance.

Unfortunately this does not solve my problem that my Panasonic DP-UB824 Blu-ray player cannot connect. I am looking into that problem next. It may take some time because I don't know anything about DLNA or the Jellyfin code base. But I know how to read C# code and to use Wireshark.