### PR TITLE
fix: the responses to several requests returns erroneous values

### DIFF
--- a/src/Jellyfin.Plugin.Dlna.Model/IDlnaManager.cs
+++ b/src/Jellyfin.Plugin.Dlna.Model/IDlnaManager.cs
@@ -77,4 +77,10 @@ public interface IDlnaManager
     /// <param name="filename">The filename.</param>
     /// <returns>DlnaIconResponse.</returns>
     Stream? GetIcon(string filename);
+
+    /// <summary>
+    /// Gets the server name.
+    /// </summary>
+    /// <returns>string</returns>
+    string GetServerName();
 }

--- a/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
+++ b/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
@@ -337,7 +337,6 @@ public class DlnaServerController : ControllerBase
 
     private void SetResponse(EventSubscriptionResponse eventSubscriptionResponse)
     {
-        var text = eventSubscriptionResponse.ToString();
         Response.Headers["Server"] = _dlnaManager.GetServerName();
         Response.Headers.Append("SID", eventSubscriptionResponse.Headers["SID"]);
         Response.Headers["Timeout"] = Request.Headers["Timeout"];

--- a/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
+++ b/src/Jellyfin.Plugin.Dlna/Api/DlnaServerController.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Mime;
+using System.Reflection.PortableExecutable;
 using System.Threading.Tasks;
 using Jellyfin.Extensions;
 using Jellyfin.Plugin.Dlna.Model;
@@ -199,10 +200,10 @@ public class DlnaServerController : ControllerBase
     [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
-    [Produces(MediaTypeNames.Text.Xml)]
-    public ActionResult<EventSubscriptionResponse> ProcessMediaReceiverRegistrarEventRequest(string serverId)
+    public ActionResult ProcessMediaReceiverRegistrarEventRequest(string serverId)
     {
-        return ProcessEventRequest(_mediaReceiverRegistrar);
+        SetResponse(ProcessEventRequest(_mediaReceiverRegistrar));
+        return new EmptyResult();
     }
 
     /// <summary>
@@ -218,10 +219,10 @@ public class DlnaServerController : ControllerBase
     [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
-    [Produces(MediaTypeNames.Text.Xml)]
-    public ActionResult<EventSubscriptionResponse> ProcessContentDirectoryEventRequest(string serverId)
+    public ActionResult ProcessContentDirectoryEventRequest(string serverId)
     {
-        return ProcessEventRequest(_contentDirectory);
+        SetResponse(ProcessEventRequest(_contentDirectory));
+        return new EmptyResult();
     }
 
     /// <summary>
@@ -237,10 +238,10 @@ public class DlnaServerController : ControllerBase
     [SuppressMessage("Microsoft.Performance", "CA1801:ReviewUnusedParameters", MessageId = "serverId", Justification = "Required for DLNA")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
-    [Produces(MediaTypeNames.Text.Xml)]
-    public ActionResult<EventSubscriptionResponse> ProcessConnectionManagerEventRequest(string serverId)
+    public ActionResult ProcessConnectionManagerEventRequest(string serverId)
     {
-        return ProcessEventRequest(_connectionManager);
+        SetResponse(ProcessEventRequest(_connectionManager));
+        return new EmptyResult();
     }
 
     /// <summary>
@@ -332,5 +333,14 @@ public class DlnaServerController : ControllerBase
         }
 
         return dlnaEventManager.CancelEventSubscription(subscriptionId);
+    }
+
+    private void SetResponse(EventSubscriptionResponse eventSubscriptionResponse)
+    {
+        var text = eventSubscriptionResponse.ToString();
+        Response.Headers["Server"] = _dlnaManager.GetServerName();
+        Response.Headers.Append("SID", eventSubscriptionResponse.Headers["SID"]);
+        Response.Headers["Timeout"] = Request.Headers["Timeout"];
+        Response.ContentLength = 0;
     }
 }

--- a/src/Jellyfin.Plugin.Dlna/DlnaManager.cs
+++ b/src/Jellyfin.Plugin.Dlna/DlnaManager.cs
@@ -204,6 +204,10 @@ public class DlnaManager : IDlnaManager
         return profile;
     }
 
+    /// <summary>
+    /// Returns the server name
+    /// </summary>
+    /// <returns>string</returns>
     public string GetServerName()
     {
         return _appHost.FriendlyName;

--- a/src/Jellyfin.Plugin.Dlna/DlnaManager.cs
+++ b/src/Jellyfin.Plugin.Dlna/DlnaManager.cs
@@ -191,6 +191,11 @@ public class DlnaManager : IDlnaManager
         return profile;
     }
 
+    public string GetServerName()
+    {
+        return _appHost.FriendlyName;
+    }
+
     private bool IsMatch(IHeaderDictionary headers, DeviceIdentification profileInfo)
     {
         return profileInfo.Headers.Any(i => IsMatch(headers, i));

--- a/src/Jellyfin.Plugin.Dlna/EventSubscriptionResponse.cs
+++ b/src/Jellyfin.Plugin.Dlna/EventSubscriptionResponse.cs
@@ -35,4 +35,14 @@ public class EventSubscriptionResponse
     /// Gets the headers dictionary.
     /// </summary>
     public Dictionary<string, string> Headers { get; }
+
+    public override string ToString() 
+    {
+        if (ContentType.Equals("text/plain", StringComparison.OrdinalIgnoreCase))
+        {
+            return Content.Trim() + "\r\n" + string.Join(Environment.NewLine, Headers);
+        }
+
+        return Content;
+    }
 }

--- a/src/Jellyfin.Plugin.Dlna/EventSubscriptionResponse.cs
+++ b/src/Jellyfin.Plugin.Dlna/EventSubscriptionResponse.cs
@@ -35,14 +35,4 @@ public class EventSubscriptionResponse
     /// Gets the headers dictionary.
     /// </summary>
     public Dictionary<string, string> Headers { get; }
-
-    public override string ToString() 
-    {
-        if (ContentType.Equals("text/plain", StringComparison.OrdinalIgnoreCase))
-        {
-            return Content.Trim() + "\r\n" + string.Join(Environment.NewLine, Headers);
-        }
-
-        return Content;
-    }
 }

--- a/src/Jellyfin.Plugin.Dlna/EventSubscriptionResponse.cs
+++ b/src/Jellyfin.Plugin.Dlna/EventSubscriptionResponse.cs
@@ -19,14 +19,4 @@ public class EventSubscriptionResponse
     public string ContentType { get; set; }
 
     public Dictionary<string, string> Headers { get; }
-
-    public override string ToString() 
-    {
-        if (ContentType.Equals("text/plain", StringComparison.OrdinalIgnoreCase))
-        {
-            return Content.Trim() + "\r\n" + string.Join(Environment.NewLine, Headers);
-        }
-
-        return Content;
-    }
 }

--- a/src/Jellyfin.Plugin.Dlna/EventSubscriptionResponse.cs
+++ b/src/Jellyfin.Plugin.Dlna/EventSubscriptionResponse.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using System;
 using System.Collections.Generic;
 
 namespace Jellyfin.Plugin.Dlna;
@@ -18,4 +19,14 @@ public class EventSubscriptionResponse
     public string ContentType { get; set; }
 
     public Dictionary<string, string> Headers { get; }
+
+    public override string ToString() 
+    {
+        if (ContentType.Equals("text/plain", StringComparison.OrdinalIgnoreCase))
+        {
+            return Content.Trim() + "\r\n" + string.Join(Environment.NewLine, Headers);
+        }
+
+        return Content;
+    }
 }


### PR DESCRIPTION
The comparison of the several responses with DLNA complaint servers has shown differences and were fixed accordingly

Please bare with me but I don't know much about C# or the used frameworks. Please advise how to improve the code if necessary.

I just can tell that now my Panasonic Blu-Ray player is able to connect to the Jellyfin instance.
The display of photos, streaming of mp3 and flac, and some mpg works fine.
I intent to add a working profile for that player as soon as I have found out how to get .mkv container playing.
