### PR TITLE
Strip URL parameters (#25)

### DIFF
--- a/src/Jellyfin.Plugin.Dlna.Playback/StreamingHelpers.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/StreamingHelpers.cs
@@ -258,6 +258,7 @@ public static class StreamingHelpers
         var ext = string.IsNullOrWhiteSpace(state.OutputContainer)
             ? GetOutputFileExtension(state, mediaSource)
             : ("." + state.OutputContainer);
+        ext = ext.AsSpan().LeftPart('?').ToString();
 
         state.OutputFilePath = GetOutputFilePath(state, ext, serverConfigurationManager, streamingRequest.DeviceId, streamingRequest.PlaySessionId);
 


### PR DESCRIPTION
Hi,

This is a PR containing a patch listed in #25 to make the DLNA plugin work with the Orange TV Decoder. From my understanding, it strips URL parameters. I'm not sure of the impact for the rest of the DLNA clients as they may rely on the URL parameters. Maybe a per-profile option to strip these parameters would be more suitable?