### PR TITLE
Disable DirectStream for video playback

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToController.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToController.cs
@@ -594,7 +594,8 @@ public class PlayToController2 : ISessionController, IDisposable
                     MaxBitrate = profile.MaxStreamingBitrate,
                     MediaSourceId = mediaSourceId,
                     AudioStreamIndex = audioStreamIndex,
-                    SubtitleStreamIndex = subtitleStreamIndex
+                    SubtitleStreamIndex = subtitleStreamIndex,
+                    EnableDirectStream = false
                 }),
                 Profile = profile
             },


### PR DESCRIPTION
This pull request disables DirectStream for video playback to fix issue #23, causing Jellyfin not to transcode a video even though the DLNA profile requires it.

As stated by gnattu in [this comment](https://github.com/jellyfin/jellyfin/pull/13475#issuecomment-2629197013), DirectStream should only be used for audio playback.

Log output:
- DirectStream enabled: `PlayMethod=DirectStream, TranscodeReason=AudioCodecNotSupported`
- DirectStream disabled: `PlayMethod=Transcode, TranscodeReason=AudioCodecNotSupported`