### PR TITLE
add emby-button class to the help button

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/Configuration/config.html
+++ b/src/Jellyfin.Plugin.Dlna/Configuration/config.html
@@ -12,7 +12,7 @@
                 <div class="verticalSection verticalSection-extrabottompadding">
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">DLNA Settings:</h2>
-                        <a is="emby-button" class="raised button-alt headerHelpButton emby-button" target="_blank" href="https://github.com/jellyfin/jellyfin-plugin-dlna">${Help}</a>
+                        <a is="emby-linkbutton" class="raised button-alt headerHelpButton emby-button" target="_blank" href="https://github.com/jellyfin/jellyfin-plugin-dlna">${Help}</a>
                     </div>
                     <div class="verticalSection verticalSection-extrabottompadding">
                         <div class="checkboxContainer">


### PR DESCRIPTION
This fix the help button design, and makes it inline with other buttons through jellyfin

Normal button from the "My Extension" page : 

![image](https://github.com/user-attachments/assets/cda6409e-9ce6-4851-b02e-3b6d5f9d832c)


Help button of the DLNA plugin : 

![image](https://github.com/user-attachments/assets/9dedcf98-fd6e-4120-9a0f-ed92ddbdb7a6)


After this fix, the button is normal : 

![image](https://github.com/user-attachments/assets/be451a50-b481-4bd2-87b1-b64437856fa9)
