### PR TITLE
sonos speaker profile

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/Profiles/Xml/Sonos.xml
+++ b/src/Jellyfin.Plugin.Dlna/Profiles/Xml/Sonos.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0"?>
+<Profile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Name>Sonos</Name>
+
+  <Identification>
+    <Manufacturer>Sonos, Inc.</Manufacturer>
+  </Identification>
+
+  <MusicStreamingTranscodingBitrate>355000</MusicStreamingTranscodingBitrate>
+
+  <DirectPlayProfiles>
+    <DirectPlayProfile type="Audio" container="mp3"/>
+    <DirectPlayProfile type="Audio" container="mp4"/>
+    <DirectPlayProfile type="Audio" container="m4a"/>
+    <DirectPlayProfile type="Audio" container="wma"/>
+    <DirectPlayProfile type="Audio" container="aac"/>
+    <DirectPlayProfile type="Audio" container="he-aac"/>
+    <DirectPlayProfile type="Audio" container="ogg"/>
+    <DirectPlayProfile type="Audio" container="flac"/>
+    <DirectPlayProfile type="Audio" container="alac"/>
+    <DirectPlayProfile type="Audio" container="aiff"/>
+    <DirectPlayProfile type="Audio" container="wav"/>
+  </DirectPlayProfiles>
+
+  <CodecProfiles>
+    <CodecProfile type="Audio" container="mp3">
+      <Conditions>
+        <ProfileCondition condition="LessThanEqual" property="AudioSampleRate" value="48000" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioChannels" value="2" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioBitrate" value="320000" isRequired="true" />
+      </Conditions>
+      <ApplyConditions />
+    </CodecProfile>
+    <CodecProfile type="Audio" container="mp4">
+      <Conditions>
+        <ProfileCondition condition="LessThanEqual" property="AudioSampleRate" value="48000" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioChannels" value="2" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioBitrate" value="320000" isRequired="true" />
+      </Conditions>
+      <ApplyConditions />
+    </CodecProfile>
+    <CodecProfile type="Audio" container="m4a">
+      <Conditions>
+        <ProfileCondition condition="LessThanEqual" property="AudioSampleRate" value="48000" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioChannels" value="2" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioBitrate" value="320000" isRequired="true" />
+      </Conditions>
+      <ApplyConditions />
+    </CodecProfile>
+    <CodecProfile type="Audio" container="wma">
+      <Conditions>
+        <ProfileCondition condition="LessThanEqual" property="AudioSampleRate" value="48000" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioChannels" value="2" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioBitrate" value="355000" isRequired="true" />
+      </Conditions>
+      <ApplyConditions />
+    </CodecProfile>
+    <CodecProfile type="Audio" container="aac">
+      <Conditions>
+        <ProfileCondition condition="LessThanEqual" property="AudioSampleRate" value="48000" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioChannels" value="2" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioBitrate" value="320000" isRequired="true" />
+      </Conditions>
+      <ApplyConditions />
+    </CodecProfile>
+    <CodecProfile type="Audio" container="he-aac">
+      <Conditions>
+        <ProfileCondition condition="LessThanEqual" property="AudioSampleRate" value="48000" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioChannels" value="2" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioBitrate" value="320000" isRequired="true" />
+      </Conditions>
+      <ApplyConditions />
+    </CodecProfile>
+    <CodecProfile type="Audio" container="ogg">
+      <Conditions>
+        <ProfileCondition condition="LessThanEqual" property="AudioSampleRate" value="48000" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioChannels" value="2" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioBitrate" value="320000" isRequired="true" />
+      </Conditions>
+      <ApplyConditions />
+    </CodecProfile>
+    <CodecProfile type="Audio" container="flac">
+      <Conditions>
+        <ProfileCondition condition="LessThanEqual" property="AudioSampleRate" value="48000" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioChannels" value="2" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioBitDepth" value="24" isRequired="true" />
+      </Conditions>
+      <ApplyConditions />
+    </CodecProfile>
+    <CodecProfile type="Audio" container="alac">
+      <Conditions>
+        <ProfileCondition condition="LessThanEqual" property="AudioSampleRate" value="48000" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioChannels" value="2" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioBitDepth" value="24" isRequired="true" />
+      </Conditions>
+      <ApplyConditions />
+    </CodecProfile>
+    <CodecProfile type="Audio" container="aiff">
+      <Conditions>
+        <ProfileCondition condition="LessThanEqual" property="AudioSampleRate" value="48000" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioChannels" value="2" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioBitDepth" value="16" isRequired="true" />
+      </Conditions>
+      <ApplyConditions />
+    </CodecProfile>
+    <CodecProfile type="Audio" container="wav">
+      <Conditions>
+        <ProfileCondition condition="LessThanEqual" property="AudioSampleRate" value="48000" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioChannels" value="2" isRequired="true" />
+        <ProfileCondition condition="LessThanEqual" property="AudioBitDepth" value="16" isRequired="true" />
+      </Conditions>
+      <ApplyConditions />
+    </CodecProfile>
+  </CodecProfiles>
+
+  <TranscodingProfiles>
+    <TranscodingProfile type="Audio" container="flac" audioCodec="flac" context="Streaming"/>
+  </TranscodingProfiles>
+
+</Profile>


### PR DESCRIPTION
Hello!

I've been painstakingly trying to get Jellyfin to play nicely with my Sonos speakers and it turns out I needed to configure the DLNA plugin to transcode some higher bitrate files to something that Sonos would be able to play.

Here's my xml profile for the speaker, with settings based on [Sonos' supported formats](https://support.sonos.com/en-us/article/supported-audio-formats-for-sonos-music-library). I had no idea what I'm doing going in and likely there's some magic properties that I've missed somewhere, but for me it works on pretty much everything now. I've chosen FLAC output for the transcoding if required, to have a lossless format in case of lossless input files. I don't know if that's correct to also apply it for lossy files, but it's all I could figure out by looking at the code.

Also, there is a mention on the Sonos site that FLAC and ALAC are only supported in 16 bit on some devices (those compatible with Sonos S1 older app) but my file tells it to transcode only if exceeding 24 bit. I don't know how to handle both scenarios, I guess by a different profile file for those older devices? If so, I'm not sure what conditions to put in the `<Identification>` tag to match correctly both device types, since I only have my Sonos One & Beam to test on, and both are S2 devices.

I guess this is better than nothing as a starting point and hopefully it will help other people. I'm happy to update the file if there's something missing or if someone clarifies how to distinguish S1-S2 devices and could help test.

Thanks!