### PR TITLE
Workaround Fixes for DLNA Virtual/Grouped Libraries returning 0 Items

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -877,14 +877,48 @@ public class ControlHandler : BaseControlHandler
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
     private QueryResult<ServerItem> GetChildrenOfItem(BaseItem parent, InternalItemsQuery query, BaseItemKind itemType, bool isFavorite = false)
     {
-        query.Recursive = true;
-        query.Parent = parent;
         query.IsFavorite = isFavorite;
         query.IncludeItemTypes = [itemType];
+        query.DtoOptions = GetDtoOptions();
 
-        var result = _libraryManager.GetItemsResult(query);
+        // For music items, use UserViewManager like GetLatest does (but not for favorites)
+        if (!isFavorite && (itemType == BaseItemKind.MusicAlbum || itemType == BaseItemKind.Audio))
+        {
+            var items = _userViewManager.GetLatestItems(
+                new LatestItemsQuery
+                {
+                    User = query.User!,
+                    Limit = query.Limit ?? 1000,
+                    IncludeItemTypes = [itemType],
+                    ParentId = parent?.Id ?? Guid.Empty,
+                    GroupItems = false
+                },
+                query.DtoOptions).Select(i => i.Item1 ?? i.Item2.FirstOrDefault()).OfType<BaseItem>().ToArray();
 
-        return ToResult(query.StartIndex, result);
+            if (query.StartIndex > 0)
+            {
+                items = (items.Length <= query.StartIndex) ? [] : items[query.StartIndex.Value..];
+            }
+
+            return ToResult(query.StartIndex, items);
+        }
+
+
+        if (parent is Folder folder)
+        {
+            var folderResult = folder.GetItems(query);
+            if (folderResult.TotalRecordCount > 0)
+            {
+                return ToResult(query.StartIndex, folderResult);
+            }
+        }
+
+        query.Recursive = true;
+        query.Parent = parent;
+
+        var libraryResult = _libraryManager.GetItemsResult(query);
+
+        return ToResult(query.StartIndex, libraryResult);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes https://github.com/jellyfin/jellyfin-plugin-dlna/issues/178

In short, the query path for the 10.11 version of Jellyfin has optimization in place that tries to use PhysicalFolderIds when certain query attributes are set. However, these do not exist for virtual or grouped items (like Albums and TV Shows), which caused them to have a random GUID returned, leading to 0 matches on those queries.

The "Latest" folder DLNA queries use a different codepath (UserViewManager) to return items, causing them to not hit the LibraryManager.GetItemsResult() optimization bug. 

These changes bypass the GetItemsResult() codepath for Albums by using the UserViewManager code to fetch all Albums, and for TV Shows (and other virtualized folders other than Albums)  by calling GetItems() directly, without relying on the faulty GetItemsResult().

Tested on both Windows and Linux, and seems to work nicely.