### PR TITLE
Fix DLNA live TV playback and tuner release

### DIFF
--- a/Jellyfin.Plugin.Dlna.sln
+++ b/Jellyfin.Plugin.Dlna.sln
@@ -14,30 +14,85 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rssdp", "src\Rssdp\Rssdp.cs
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.Dlna.Playback", "src\Jellyfin.Plugin.Dlna.Playback\Jellyfin.Plugin.Dlna.Playback.csproj", "{D5627E87-BB93-426A-B067-AE84DFAD1E84}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.Dlna.Tests", "tests\Jellyfin.Plugin.Dlna.Tests\Jellyfin.Plugin.Dlna.Tests.csproj", "{DC48FEB3-1501-425D-B272-00735BB86992}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x64.Build.0 = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x86.Build.0 = Debug|Any CPU
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x64.ActiveCfg = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x64.Build.0 = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x86.ActiveCfg = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x86.Build.0 = Release|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x64.Build.0 = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x86.Build.0 = Debug|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x64.ActiveCfg = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x64.Build.0 = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x86.ActiveCfg = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x86.Build.0 = Release|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x64.Build.0 = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x86.Build.0 = Debug|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x64.ActiveCfg = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x64.Build.0 = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x86.ActiveCfg = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x86.Build.0 = Release|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x64.Build.0 = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x86.Build.0 = Debug|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x64.ActiveCfg = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x64.Build.0 = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x86.ActiveCfg = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x86.Build.0 = Release|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Debug|x64.Build.0 = Debug|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Debug|x86.Build.0 = Debug|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Release|x64.ActiveCfg = Release|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Release|x64.Build.0 = Release|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Release|x86.ActiveCfg = Release|Any CPU
+		{DC48FEB3-1501-425D-B272-00735BB86992}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{DC48FEB3-1501-425D-B272-00735BB86992} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/Jellyfin.Plugin.Dlna.Model/DlnaPluginConfigurationAccessor.cs
+++ b/src/Jellyfin.Plugin.Dlna.Model/DlnaPluginConfigurationAccessor.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Jellyfin.Plugin.Dlna.Model;
+
+/// <summary>
+/// Shared DLNA plugin configuration for assemblies that cannot reference the main plugin assembly.
+/// </summary>
+public static class DlnaPluginConfigurationAccessor
+{
+    /// <summary>
+    /// Gets or sets the default user configured under DLNA plugin settings.
+    /// </summary>
+    public static Guid? DefaultUserId { get; set; }
+}

--- a/src/Jellyfin.Plugin.Dlna.Playback/Api/DlnaVideosController.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/Api/DlnaVideosController.cs
@@ -325,6 +325,7 @@ public class DlnaVideosController : ControllerBase
             isHeadRequest,
             HttpContext,
             _transcodingJobHelper,
+            _mediaSourceManager,
             ffmpegCommandLineArguments,
             _transcodingJobType,
             cancellationTokenSource).ConfigureAwait(false);

--- a/src/Jellyfin.Plugin.Dlna.Playback/AudioHelper.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/AudioHelper.cs
@@ -173,6 +173,7 @@ public class AudioHelper
             isHeadRequest,
             _httpContextAccessor.HttpContext,
             _transcodeManager,
+            _mediaSourceManager,
             ffmpegCommandLineArguments,
             transcodingJobType,
             cancellationTokenSource).ConfigureAwait(false);

--- a/src/Jellyfin.Plugin.Dlna.Playback/DlnaLiveProgressiveFileStream.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/DlnaLiveProgressiveFileStream.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Model.IO;
+
+namespace Jellyfin.Plugin.Dlna.Playback;
+
+/// <summary>
+/// Progressive file stream for DLNA live TV. Short probe connections do not stop transcoding;
+/// sustained playback does, and all tuner consumers opened by DLNA probes are released when playback stops.
+/// </summary>
+internal sealed class DlnaLiveProgressiveFileStream : Stream
+{
+    /// <summary>
+    /// Bytes below this are treated as a HEAD/GET probe, not a viewing session.
+    /// </summary>
+    public const long ProbeBytesThreshold = 65536;
+
+    private readonly Stream _stream;
+    private readonly TranscodingJob? _job;
+    private readonly ITranscodeManager? _transcodeManager;
+    private readonly IMediaSourceManager? _mediaSourceManager;
+    private readonly string? _liveStreamId;
+    private readonly int _timeoutMs;
+    private readonly long _bytesAtOpen;
+    private bool _disposed;
+
+    public DlnaLiveProgressiveFileStream(
+        string filePath,
+        TranscodingJob? job,
+        ITranscodeManager transcodeManager,
+        IMediaSourceManager mediaSourceManager,
+        string? liveStreamId,
+        int timeoutMs = 90000)
+    {
+        _job = job;
+        _transcodeManager = transcodeManager;
+        _mediaSourceManager = mediaSourceManager;
+        _liveStreamId = liveStreamId;
+        _bytesAtOpen = job?.BytesDownloaded ?? 0;
+        _timeoutMs = timeoutMs;
+        _stream = new FileStream(
+            filePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite,
+            IODefaults.FileStreamBufferSize,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+    }
+
+    public override bool CanRead => _stream.CanRead;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => false;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+        => Read(buffer.AsSpan(offset, count));
+
+    public override int Read(Span<byte> buffer)
+    {
+        int totalBytesRead = 0;
+        var stopwatch = Stopwatch.StartNew();
+
+        while (true)
+        {
+            totalBytesRead += _stream.Read(buffer);
+            if (StopReading(totalBytesRead, stopwatch.ElapsedMilliseconds))
+            {
+                break;
+            }
+
+            Thread.Sleep(50);
+        }
+
+        UpdateBytesWritten(totalBytesRead);
+
+        return totalBytesRead;
+    }
+
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => await ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        int totalBytesRead = 0;
+        var stopwatch = Stopwatch.StartNew();
+
+        while (true)
+        {
+            totalBytesRead += await _stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (StopReading(totalBytesRead, stopwatch.ElapsedMilliseconds))
+            {
+                break;
+            }
+
+            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+        }
+
+        UpdateBytesWritten(totalBytesRead);
+
+        return totalBytesRead;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+        => throw new NotSupportedException();
+
+    public override void SetLength(long value)
+        => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count)
+        => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            _stream.Dispose();
+            ScheduleTeardownIfNeeded();
+        }
+
+        _disposed = true;
+        base.Dispose(disposing);
+    }
+
+    private void ScheduleTeardownIfNeeded()
+    {
+        if (_job is null || _transcodeManager is null)
+        {
+            return;
+        }
+
+        var sessionBytes = _job.BytesDownloaded - _bytesAtOpen;
+        if (sessionBytes >= ProbeBytesThreshold)
+        {
+            DlnaLiveStreamTeardown.ScheduleAfterPlayback(
+                _job,
+                _transcodeManager,
+                _mediaSourceManager,
+                _liveStreamId);
+            return;
+        }
+
+        DlnaLiveStreamTeardown.ScheduleAfterProbe(
+            _job,
+            _transcodeManager,
+            _mediaSourceManager,
+            _liveStreamId,
+            _bytesAtOpen);
+    }
+
+    private void UpdateBytesWritten(int totalBytesRead)
+    {
+        if (_job is not null)
+        {
+            _job.BytesDownloaded += totalBytesRead;
+        }
+    }
+
+    private bool StopReading(int bytesRead, long elapsed)
+        => bytesRead > 0 || (_job?.HasExited ?? elapsed >= _timeoutMs);
+}

--- a/src/Jellyfin.Plugin.Dlna.Playback/DlnaLiveStreamTeardown.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/DlnaLiveStreamTeardown.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.Dlna.Playback;
+
+/// <summary>
+/// Stops DLNA live-TV transcoding and releases all tuner consumers opened by repeated HEAD/GET probes.
+/// </summary>
+internal static class DlnaLiveStreamTeardown
+{
+    /// <summary>
+    /// DLNA often opens the same live stream several times (HEAD, GET, metadata). Each close drops one consumer.
+    /// </summary>
+    private const int MaxCloseAttempts = 16;
+
+    private const int MaxEndRequestAttempts = 12;
+
+    private static readonly TimeSpan PlaybackEndGrace = TimeSpan.FromSeconds(1);
+
+    private static readonly TimeSpan ProbeTeardownDelay = TimeSpan.FromSeconds(45);
+
+    private static readonly ConcurrentDictionary<string, byte> _pendingTeardowns = new(StringComparer.OrdinalIgnoreCase);
+
+    public static void RegisterClientDisconnect(
+        HttpContext httpContext,
+        TranscodingJob? job,
+        ITranscodeManager transcodeManager,
+        IMediaSourceManager? mediaSourceManager,
+        string? liveStreamId,
+        long bytesAtOpen)
+    {
+        if (job is null || string.IsNullOrEmpty(job.Path))
+        {
+            return;
+        }
+
+        httpContext.RequestAborted.Register(() =>
+        {
+            var sessionBytes = job.BytesDownloaded - bytesAtOpen;
+            if (sessionBytes >= DlnaLiveProgressiveFileStream.ProbeBytesThreshold)
+            {
+                ScheduleAfterPlayback(job, transcodeManager, mediaSourceManager, liveStreamId);
+            }
+            else
+            {
+                ScheduleAfterProbe(job, transcodeManager, mediaSourceManager, liveStreamId, bytesAtOpen);
+            }
+        });
+    }
+
+    public static void ScheduleAfterPlayback(
+        TranscodingJob? job,
+        ITranscodeManager transcodeManager,
+        IMediaSourceManager? mediaSourceManager,
+        string? liveStreamId)
+    {
+        ScheduleTeardown(job, transcodeManager, mediaSourceManager, liveStreamId, PlaybackEndGrace);
+    }
+
+    public static void ScheduleAfterProbe(
+        TranscodingJob? job,
+        ITranscodeManager transcodeManager,
+        IMediaSourceManager? mediaSourceManager,
+        string? liveStreamId,
+        long bytesAtOpen)
+    {
+        if (job is null || string.IsNullOrEmpty(job.Path))
+        {
+            return;
+        }
+
+        if (!_pendingTeardowns.TryAdd(job.Path + ":probe", 0))
+        {
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(ProbeTeardownDelay).ConfigureAwait(false);
+
+                if (job.HasExited)
+                {
+                    return;
+                }
+
+                if (job.BytesDownloaded - bytesAtOpen >= DlnaLiveProgressiveFileStream.ProbeBytesThreshold)
+                {
+                    return;
+                }
+
+                await ForceTeardownAsync(job, transcodeManager, mediaSourceManager, liveStreamId).ConfigureAwait(false);
+            }
+            finally
+            {
+                _pendingTeardowns.TryRemove(job.Path + ":probe", out _);
+            }
+        });
+    }
+
+    private static void ScheduleTeardown(
+        TranscodingJob? job,
+        ITranscodeManager transcodeManager,
+        IMediaSourceManager? mediaSourceManager,
+        string? liveStreamId,
+        TimeSpan delay)
+    {
+        if (job is null || string.IsNullOrEmpty(job.Path))
+        {
+            return;
+        }
+
+        if (!_pendingTeardowns.TryAdd(job.Path, 0))
+        {
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(delay).ConfigureAwait(false);
+                await ForceTeardownAsync(job, transcodeManager, mediaSourceManager, liveStreamId).ConfigureAwait(false);
+            }
+            finally
+            {
+                _pendingTeardowns.TryRemove(job.Path, out _);
+            }
+        });
+    }
+
+    private static async Task ForceTeardownAsync(
+        TranscodingJob job,
+        ITranscodeManager transcodeManager,
+        IMediaSourceManager? mediaSourceManager,
+        string? liveStreamId)
+    {
+        if (job.HasExited)
+        {
+            await ReleaseLiveStreamAsync(mediaSourceManager, !string.IsNullOrWhiteSpace(liveStreamId) ? liveStreamId : job.LiveStreamId).ConfigureAwait(false);
+            return;
+        }
+
+        var streamId = !string.IsNullOrWhiteSpace(liveStreamId) ? liveStreamId : job.LiveStreamId;
+
+        // Stop ffmpeg immediately (progressive kill timer is unreliable for DLNA).
+        if (job.CancellationTokenSource is { IsCancellationRequested: false })
+        {
+            await job.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
+        }
+
+        await ReleaseLiveStreamAsync(mediaSourceManager, streamId).ConfigureAwait(false);
+
+        for (var i = 0; i < MaxEndRequestAttempts && job.ActiveRequestCount > 0; i++)
+        {
+            transcodeManager.OnTranscodeEndRequest(job);
+        }
+
+        if (job.ActiveRequestCount > 0)
+        {
+            job.ActiveRequestCount = 0;
+            transcodeManager.OnTranscodeEndRequest(job);
+        }
+    }
+
+    private static async Task ReleaseLiveStreamAsync(IMediaSourceManager? mediaSourceManager, string? liveStreamId)
+    {
+        if (mediaSourceManager is null || string.IsNullOrWhiteSpace(liveStreamId))
+        {
+            return;
+        }
+
+        for (var i = 0; i < MaxCloseAttempts; i++)
+        {
+            try
+            {
+                await mediaSourceManager.CloseLiveStream(liveStreamId).ConfigureAwait(false);
+            }
+            catch
+            {
+                break;
+            }
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.Dlna.Playback/DlnaStreamRequestAdjustments.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/DlnaStreamRequestAdjustments.cs
@@ -1,0 +1,42 @@
+using Jellyfin.Plugin.Dlna.Playback.Model;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Dto;
+
+namespace Jellyfin.Plugin.Dlna.Playback;
+
+/// <summary>
+/// Adjusts DLNA stream requests once the probed media source is available.
+/// </summary>
+public static class DlnaStreamRequestAdjustments
+{
+    /// <summary>
+    /// Live TV browse URLs often omit MaxWidth/MaxHeight. Without caps, playback upgrades to native
+    /// 4K when bitrate allows it. Limit DLNA live transcodes to 1080p.
+    /// </summary>
+    public static void CapLiveStreamTranscodeResolution(DlnaStreamState state, MediaSourceInfo? mediaSource)
+        => CapLiveStreamTranscodeResolution(state.VideoRequest, mediaSource);
+
+    /// <summary>
+    /// Caps live stream transcode resolution to 1080p when width/height are missing or higher.
+    /// </summary>
+    public static void CapLiveStreamTranscodeResolution(VideoRequestDto? videoRequest, MediaSourceInfo? mediaSource)
+    {
+        if (videoRequest is null || mediaSource is null || !mediaSource.IsInfiniteStream)
+        {
+            return;
+        }
+
+        const int maxWidth = 1920;
+        const int maxHeight = 1080;
+
+        if (!videoRequest.MaxWidth.HasValue || videoRequest.MaxWidth.Value > maxWidth)
+        {
+            videoRequest.MaxWidth = maxWidth;
+        }
+
+        if (!videoRequest.MaxHeight.HasValue || videoRequest.MaxHeight.Value > maxHeight)
+        {
+            videoRequest.MaxHeight = maxHeight;
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.Dlna.Playback/FileStreamResponseHelpers.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/FileStreamResponseHelpers.cs
@@ -5,6 +5,7 @@ using System.Net.Mime;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Dlna.Playback.Extensions;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Streaming;
 using Microsoft.AspNetCore.Http;
@@ -66,6 +67,7 @@ public static class FileStreamResponseHelpers
     /// <param name="isHeadRequest">Whether the current request is a HTTP HEAD request so only the headers get returned.</param>
     /// <param name="httpContext">The current http context.</param>
     /// <param name="transcodeManager">The <see cref="ITranscodeManager"/> singleton.</param>
+    /// <param name="mediaSourceManager">The <see cref="IMediaSourceManager"/> singleton.</param>
     /// <param name="ffmpegCommandLineArguments">The command line arguments to start ffmpeg.</param>
     /// <param name="transcodingJobType">The <see cref="TranscodingJobType"/>.</param>
     /// <param name="cancellationTokenSource">The <see cref="CancellationTokenSource"/>.</param>
@@ -75,6 +77,7 @@ public static class FileStreamResponseHelpers
         bool isHeadRequest,
         HttpContext httpContext,
         ITranscodeManager transcodeManager,
+        IMediaSourceManager mediaSourceManager,
         string ffmpegCommandLineArguments,
         TranscodingJobType transcodingJobType,
         CancellationTokenSource cancellationTokenSource)
@@ -85,17 +88,11 @@ public static class FileStreamResponseHelpers
         httpContext.Response.Headers[HeaderNames.AcceptRanges] = "none";
 
         var contentType = state.GetMimeType(outputPath);
-
-        // Headers only
-        if (isHeadRequest)
-        {
-            httpContext.Response.Headers[HeaderNames.ContentType] = contentType;
-            return new OkResult();
-        }
+        var isLiveTv = state.MediaSource.IsInfiniteStream;
 
         using var transcodingLock = await transcodeManager.LockAsync(outputPath, cancellationTokenSource.Token).ConfigureAwait(false);
 
-        TranscodingJob? job;
+        TranscodingJob? job = null;
         if (!File.Exists(outputPath))
         {
             job = await transcodeManager.StartFfMpeg(
@@ -105,14 +102,55 @@ public static class FileStreamResponseHelpers
                 httpContext.User.GetUserId(),
                 transcodingJobType,
                 cancellationTokenSource).ConfigureAwait(false);
+
+            if (isLiveTv)
+            {
+                job.IsLiveOutput = true;
+                job.StopKillTimer();
+            }
         }
         else
         {
-            job = transcodeManager.OnTranscodeBeginRequest(outputPath, TranscodingJobType.Progressive);
-            state.Dispose();
+            // HEAD already started the job; do not bump ActiveRequestCount again for live TV.
+            if (!isLiveTv)
+            {
+                job = transcodeManager.OnTranscodeBeginRequest(outputPath, TranscodingJobType.Progressive);
+            }
+            else
+            {
+                job = transcodeManager.GetTranscodingJob(outputPath, TranscodingJobType.Progressive);
+            }
+
+            job?.StopKillTimer();
         }
 
-        var stream = new ProgressiveFileStream(outputPath, job, transcodeManager);
-        return new FileStreamResult(stream, contentType);
+        // Many DLNA clients send HEAD before GET; start transcoding on HEAD so the first GET has data ready.
+        if (isHeadRequest)
+        {
+            httpContext.Response.Headers[HeaderNames.ContentType] = contentType;
+            return new OkResult();
+        }
+
+        if (isLiveTv && job is not null)
+        {
+            var bytesAtOpen = job.BytesDownloaded;
+            DlnaLiveStreamTeardown.RegisterClientDisconnect(
+                httpContext,
+                job,
+                transcodeManager,
+                mediaSourceManager,
+                state.MediaSource.LiveStreamId,
+                bytesAtOpen);
+
+            var stream = new DlnaLiveProgressiveFileStream(
+                outputPath,
+                job,
+                transcodeManager,
+                mediaSourceManager,
+                state.MediaSource.LiveStreamId);
+            return new FileStreamResult(stream, contentType);
+        }
+
+        return new FileStreamResult(new ProgressiveFileStream(outputPath, job, transcodeManager), contentType);
     }
 }

--- a/src/Jellyfin.Plugin.Dlna.Playback/StreamingHelpers.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/StreamingHelpers.cs
@@ -19,6 +19,7 @@ using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Streaming;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.MediaInfo;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -107,6 +108,10 @@ public static class StreamingHelpers
         {
             state.User = userManager.GetUserById(userId);
         }
+        else
+        {
+            state.User = GetDefaultDlnaUser(userManager);
+        }
 
         if (state.IsVideoRequest && !string.IsNullOrWhiteSpace(state.Request.VideoCodec))
         {
@@ -146,13 +151,21 @@ public static class StreamingHelpers
 
             if (mediaSource is null)
             {
-                var mediaSources = await mediaSourceManager.GetPlaybackMediaSources(libraryManager.GetItemById(streamingRequest.Id), null, false, false, cancellationToken).ConfigureAwait(false);
+                var mediaSources = await mediaSourceManager.GetPlaybackMediaSources(
+                    libraryManager.GetItemById(streamingRequest.Id),
+                    state.User,
+                    false,
+                    false,
+                    cancellationToken).ConfigureAwait(false);
 
                 mediaSource = string.IsNullOrEmpty(streamingRequest.MediaSourceId)
                     ? mediaSources[0]
-                    : mediaSources.First(i => string.Equals(i.Id, streamingRequest.MediaSourceId, StringComparison.Ordinal));
+                    : mediaSources.FirstOrDefault(i => string.Equals(i.Id, streamingRequest.MediaSourceId, StringComparison.Ordinal));
 
-                if (mediaSource is null && Guid.Parse(streamingRequest.MediaSourceId).Equals(streamingRequest.Id))
+                if (mediaSource is null
+                    && !string.IsNullOrEmpty(streamingRequest.MediaSourceId)
+                    && Guid.TryParse(streamingRequest.MediaSourceId, out var mediaSourceGuid)
+                    && mediaSourceGuid.Equals(streamingRequest.Id))
                 {
                     mediaSource = mediaSources[0];
                 }
@@ -165,15 +178,50 @@ public static class StreamingHelpers
             state.DirectStreamProvider = liveStreamInfo.Item2;
         }
 
+        // Many DLNA clients do not call /LiveStreams/Open before playback. Open the tuner
+        // here so MediaPath points at LiveStreamFiles/... instead of the placeholder LAN base URL.
+        if (mediaSource is not null
+            && mediaSource.RequiresOpening
+            && string.IsNullOrWhiteSpace(streamingRequest.LiveStreamId)
+            && string.IsNullOrWhiteSpace(mediaSource.LiveStreamId)
+            && !string.IsNullOrWhiteSpace(mediaSource.OpenToken))
+        {
+            var liveStreamRequest = new LiveStreamRequest
+            {
+                OpenToken = mediaSource.OpenToken,
+                ItemId = streamingRequest.Id
+            };
+
+            if (state.User is not null)
+            {
+                liveStreamRequest.UserId = state.User.Id;
+            }
+
+            var openResult = await mediaSourceManager.OpenLiveStreamInternal(liveStreamRequest, cancellationToken)
+                .ConfigureAwait(false);
+            mediaSource = openResult.Item1.MediaSource;
+            state.DirectStreamProvider = openResult.Item2;
+            streamingRequest.LiveStreamId = mediaSource.LiveStreamId;
+        }
+
         var encodingOptions = serverConfigurationManager.GetEncodingOptions();
 
         encodingHelper.AttachMediaSourceInfo(state, encodingOptions, mediaSource, url);
+
+        DlnaStreamRequestAdjustments.CapLiveStreamTranscodeResolution(state, mediaSource);
 
         string? containerInternal = Path.GetExtension(state.RequestedUrl);
 
         if (!string.IsNullOrEmpty(streamingRequest.Container))
         {
             containerInternal = streamingRequest.Container;
+        }
+
+        if (string.IsNullOrEmpty(containerInternal)
+            && (!string.IsNullOrWhiteSpace(streamingRequest.LiveStreamId)
+                || (mediaSource?.IsInfiniteStream ?? false)))
+        {
+            containerInternal = ".ts";
         }
 
         if (string.IsNullOrEmpty(containerInternal))
@@ -839,5 +887,16 @@ public static class StreamingHelpers
                     break;
             }
         }
+    }
+
+    private static Jellyfin.Database.Implementations.Entities.User? GetDefaultDlnaUser(IUserManager userManager)
+    {
+        var defaultUserId = DlnaPluginConfigurationAccessor.DefaultUserId;
+        if (defaultUserId is null || defaultUserId.Value.Equals(default))
+        {
+            return null;
+        }
+
+        return userManager.GetUserById(defaultUserId.Value);
     }
 }

--- a/src/Jellyfin.Plugin.Dlna/DlnaPlugin.cs
+++ b/src/Jellyfin.Plugin.Dlna/DlnaPlugin.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.Dlna.Configuration;
+using Jellyfin.Plugin.Dlna.Model;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
@@ -27,6 +28,19 @@ public class DlnaPlugin : BasePlugin<DlnaPluginConfiguration>, IHasWebPages
         : base(applicationPaths, xmlSerializer)
     {
         Instance = this;
+        SyncConfigurationAccessor();
+    }
+
+    /// <inheritdoc />
+    public override void UpdateConfiguration(BasePluginConfiguration configuration)
+    {
+        base.UpdateConfiguration(configuration);
+        SyncConfigurationAccessor();
+    }
+
+    private static void SyncConfigurationAccessor()
+    {
+        DlnaPluginConfigurationAccessor.DefaultUserId = Instance.Configuration.DefaultUserId;
     }
 
     /// <inheritdoc />

--- a/tests/Jellyfin.Plugin.Dlna.Tests/DlnaStreamRequestAdjustmentsTests.cs
+++ b/tests/Jellyfin.Plugin.Dlna.Tests/DlnaStreamRequestAdjustmentsTests.cs
@@ -1,0 +1,57 @@
+using Jellyfin.Plugin.Dlna.Playback;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Dto;
+using Xunit;
+
+namespace Jellyfin.Plugin.Dlna.Tests;
+
+public class DlnaStreamRequestAdjustmentsTests
+{
+    [Fact]
+    public void CapLiveStreamTranscodeResolution_LimitsUnboundedLiveStreamTo1080p()
+    {
+        var request = new VideoRequestDto();
+        var mediaSource = new MediaSourceInfo { IsInfiniteStream = true };
+
+        DlnaStreamRequestAdjustments.CapLiveStreamTranscodeResolution(request, mediaSource);
+
+        Assert.Equal(1920, request.MaxWidth);
+        Assert.Equal(1080, request.MaxHeight);
+    }
+
+    [Fact]
+    public void CapLiveStreamTranscodeResolution_ReducesOversizedLiveStreamCaps()
+    {
+        var request = new VideoRequestDto { MaxWidth = 3840, MaxHeight = 2160 };
+        var mediaSource = new MediaSourceInfo { IsInfiniteStream = true };
+
+        DlnaStreamRequestAdjustments.CapLiveStreamTranscodeResolution(request, mediaSource);
+
+        Assert.Equal(1920, request.MaxWidth);
+        Assert.Equal(1080, request.MaxHeight);
+    }
+
+    [Fact]
+    public void CapLiveStreamTranscodeResolution_DoesNotUpscaleSmallerCaps()
+    {
+        var request = new VideoRequestDto { MaxWidth = 1280, MaxHeight = 720 };
+        var mediaSource = new MediaSourceInfo { IsInfiniteStream = true };
+
+        DlnaStreamRequestAdjustments.CapLiveStreamTranscodeResolution(request, mediaSource);
+
+        Assert.Equal(1280, request.MaxWidth);
+        Assert.Equal(720, request.MaxHeight);
+    }
+
+    [Fact]
+    public void CapLiveStreamTranscodeResolution_SkipsNonLiveSources()
+    {
+        var request = new VideoRequestDto { MaxWidth = 3840, MaxHeight = 2160 };
+        var mediaSource = new MediaSourceInfo { IsInfiniteStream = false };
+
+        DlnaStreamRequestAdjustments.CapLiveStreamTranscodeResolution(request, mediaSource);
+
+        Assert.Equal(3840, request.MaxWidth);
+        Assert.Equal(2160, request.MaxHeight);
+    }
+}

--- a/tests/Jellyfin.Plugin.Dlna.Tests/Jellyfin.Plugin.Dlna.Tests.csproj
+++ b/tests/Jellyfin.Plugin.Dlna.Tests/Jellyfin.Plugin.Dlna.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Jellyfin.Plugin.Dlna.Playback\Jellyfin.Plugin.Dlna.Playback.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Split from the earlier combined PR per review feedback.

Some DLNA clients never call `/LiveStreams/Open` before requesting video. They may also send the channel GUID as `MediaSourceId`, probe the stream with HEAD, or disconnect after reading only a few KB. On my setup (Samsung TV + Vu+/OpenViX) that meant live TV failed to start and the tuner stayed locked after stopping playback.

This PR handles that path only:

- open the tuner during DLNA playback setup when it is still closed
- fall back to the first media source when `MediaSourceId` equals the channel id
- use the configured default DLNA user when the request is anonymous
- start live transcodes on HEAD so the following GET has data ready
- keep progressive live transcodes alive across short probe connections
- call `CloseLiveStream` once all consumers are gone
- cap live transcodes at 1080p when no lower limit is requested

## Test plan

- [x] `dotnet build`
- [x] unit tests for the 1080p live cap
- [ ] DLNA live TV starts on Samsung UE55KU6519
- [ ] stopping playback releases the Vu+ tuner
- [ ] library/VOD DLNA playback still works

Related follow-ups in separate PRs: programme dates, optional subtitle delivery.