### PR TITLE
Fix IUserManager.Users -> GetUsers() for Jellyfin 10.11.9

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ContentDirectoryService.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ContentDirectoryService.cs
@@ -152,7 +152,7 @@ public class ContentDirectoryService : BaseService, IContentDirectory
             }
         }
 
-        foreach (var user in _userManager.Users)
+        foreach (var user in _userManager.GetUsers())
         {
             if (user.HasPermission(PermissionKind.IsAdministrator))
             {
@@ -160,6 +160,6 @@ public class ContentDirectoryService : BaseService, IContentDirectory
             }
         }
 
-        return _userManager.Users.FirstOrDefault();
+        return _userManager.GetUsers().FirstOrDefault();
     }
 }


### PR DESCRIPTION
Replace removed `IUserManager.Users` property with `GetUsers()` so the plugin builds against Jellyfin 10.11.9.

Jellyfin 10.11.9 backported the `IUserManager.Users` → `GetUsers()` API change from 12.x (see [jellyfin/jellyfin@2ac0edc](https://github.com/jellyfin/jellyfin/commit/2ac0edc052ed5d22cee3d46fb933bb12a2b36283)), so the current master branch no longer compiles against stable.

Mirrors the equivalent change made on `unstable` in commit 6bd2247 (excluding the unrelated Jellyfin 12.x `videoRotation` parameter).

Build error before this change:
```
src/Jellyfin.Plugin.Dlna/ContentDirectory/ContentDirectoryService.cs(155,43): error CS1061: 'IUserManager' does not contain a definition for 'Users'
src/Jellyfin.Plugin.Dlna/ContentDirectory/ContentDirectoryService.cs(163,29): error CS1061: 'IUserManager' does not contain a definition for 'Users'
```