### PR TITLE
Fix live TV programme dates in DLNA metadata

### DIFF
--- a/Jellyfin.Plugin.Dlna.sln
+++ b/Jellyfin.Plugin.Dlna.sln
@@ -14,30 +14,85 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rssdp", "src\Rssdp\Rssdp.cs
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.Dlna.Playback", "src\Jellyfin.Plugin.Dlna.Playback\Jellyfin.Plugin.Dlna.Playback.csproj", "{D5627E87-BB93-426A-B067-AE84DFAD1E84}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.Dlna.Tests", "tests\Jellyfin.Plugin.Dlna.Tests\Jellyfin.Plugin.Dlna.Tests.csproj", "{4409C05C-C1F5-49FE-A564-DE6856A70939}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x64.Build.0 = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x86.Build.0 = Debug|Any CPU
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x64.ActiveCfg = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x64.Build.0 = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x86.ActiveCfg = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x86.Build.0 = Release|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x64.Build.0 = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x86.Build.0 = Debug|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x64.ActiveCfg = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x64.Build.0 = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x86.ActiveCfg = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x86.Build.0 = Release|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x64.Build.0 = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x86.Build.0 = Debug|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x64.ActiveCfg = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x64.Build.0 = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x86.ActiveCfg = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x86.Build.0 = Release|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x64.Build.0 = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x86.Build.0 = Debug|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x64.ActiveCfg = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x64.Build.0 = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x86.ActiveCfg = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x86.Build.0 = Release|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Debug|x64.Build.0 = Debug|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Debug|x86.Build.0 = Debug|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Release|x64.ActiveCfg = Release|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Release|x64.Build.0 = Release|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Release|x86.ActiveCfg = Release|Any CPU
+		{4409C05C-C1F5-49FE-A564-DE6856A70939}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{4409C05C-C1F5-49FE-A564-DE6856A70939} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
@@ -6,12 +6,15 @@ using System.Text;
 using System.Xml;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.Dlna.ContentDirectory;
 using Jellyfin.Plugin.Dlna.Extensions;
 using Jellyfin.Plugin.Dlna.Model;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Drawing;
+using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
@@ -21,6 +24,7 @@ using MediaBrowser.Model.Drawing;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Net;
+using MediaBrowser.Model.Querying;
 using Microsoft.Extensions.Logging;
 using Episode = MediaBrowser.Controller.Entities.TV.Episode;
 using Genre = MediaBrowser.Controller.Entities.Genre;
@@ -790,11 +794,14 @@ public class DidlBuilder
 
         if (filter.Contains("dc:date"))
         {
-            if (item.PremiereDate.HasValue)
+            var displayDateUtc = GetItemDisplayDateUtc(item, _user);
+            if (displayDateUtc.HasValue)
             {
-                AddValue(writer, "dc", "date", item.PremiereDate.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), NsDc);
+                AddValue(writer, "dc", "date", DlnaItemDisplayDate.FormatDlnaDateTime(displayDateUtc.Value), NsDc);
             }
         }
+
+        AddLiveTvBroadcastFields(item, _user, writer, filter);
 
         if (filter.Contains("upnp:genre"))
         {
@@ -844,6 +851,89 @@ public class DidlBuilder
         }
 
         AddPeople(item, writer);
+    }
+
+    private DateTime? GetItemDisplayDateUtc(BaseItem item, User? user)
+    {
+        if (item is LiveTvProgram program)
+        {
+            return DlnaItemDisplayDate.GetProgramDisplayDateUtc(program.StartDate);
+        }
+
+        if (item is LiveTvChannel channel)
+        {
+            var currentProgram = GetCurrentProgram(channel.Id, user);
+            return DlnaItemDisplayDate.GetChannelDisplayDateUtc(
+                currentProgram?.StartDate,
+                DateTime.UtcNow);
+        }
+
+        return DlnaItemDisplayDate.GetPremiereDisplayDateUtc(item.PremiereDate);
+    }
+
+    private LiveTvProgram? GetCurrentProgram(Guid channelId, User? user)
+    {
+        if (user is null)
+        {
+            return null;
+        }
+
+        var now = DateTime.UtcNow;
+        var query = new InternalItemsQuery(user)
+        {
+            IncludeItemTypes = [BaseItemKind.LiveTvProgram],
+            ChannelIds = [channelId],
+            MaxStartDate = now,
+            MinEndDate = now,
+            Limit = 1,
+            OrderBy = [(ItemSortBy.StartDate, SortOrder.Ascending)],
+            DtoOptions = new DtoOptions(false)
+        };
+
+        return _libraryManager.GetItemList(query).OfType<LiveTvProgram>().FirstOrDefault();
+    }
+
+    private void AddLiveTvBroadcastFields(BaseItem item, User? user, XmlWriter writer, Filter filter)
+    {
+        LiveTvProgram? program = item switch
+        {
+            LiveTvProgram p => p,
+            LiveTvChannel c => GetCurrentProgram(c.Id, user),
+            _ => null
+        };
+
+        if (program is null)
+        {
+            return;
+        }
+
+        // Some DLNA clients request dc:date for live TV but omit scheduledStartTime.
+        var includeSchedule = filter.Contains("upnp:scheduledStartTime") || filter.Contains("dc:date");
+
+        if (includeSchedule && DlnaItemDisplayDate.IsValidDlnaDate(program.StartDate))
+        {
+            AddValue(writer, "upnp", "scheduledStartTime", DlnaItemDisplayDate.FormatDlnaDateTime(program.StartDate), NsUpnp);
+        }
+
+        if ((filter.Contains("upnp:scheduledEndTime") || filter.Contains("dc:date"))
+            && program.EndDate.HasValue
+            && DlnaItemDisplayDate.IsValidDlnaDate(program.EndDate.Value))
+        {
+            AddValue(writer, "upnp", "scheduledEndTime", DlnaItemDisplayDate.FormatDlnaDateTime(program.EndDate.Value), NsUpnp);
+        }
+
+        if (item is LiveTvChannel channel)
+        {
+            if (filter.Contains("upnp:channelNr") && !string.IsNullOrEmpty(channel.Number))
+            {
+                AddValue(writer, "upnp", "channelNr", channel.Number, NsUpnp);
+            }
+
+            if (filter.Contains("upnp:channelName") && !string.IsNullOrEmpty(channel.Name))
+            {
+                AddValue(writer, "upnp", "channelName", channel.Name, NsUpnp);
+            }
+        }
     }
 
     private void WriteObjectClass(XmlWriter writer, BaseItem item, StubType? stubType)

--- a/src/Jellyfin.Plugin.Dlna/Didl/DlnaItemDisplayDate.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DlnaItemDisplayDate.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.Dlna.Didl;
+
+/// <summary>
+/// Resolves and formats dates for DLNA DIDL metadata (live TV EPG, channels).
+/// </summary>
+public static class DlnaItemDisplayDate
+{
+    /// <summary>
+    /// Returns whether a date is safe to expose to DLNA clients (avoids Unix epoch display).
+    /// </summary>
+    public static bool IsValidDlnaDate(DateTime date)
+    {
+        if (date == default || date.Year < 1980)
+        {
+            return false;
+        }
+
+        return !(date.Year == 1970 && date.Month == 1 && date.Day <= 2);
+    }
+
+    /// <summary>
+    /// Formats a UTC instant for Dublin Core / UPnP datetime fields (local wall time).
+    /// </summary>
+    public static string FormatDlnaDateTime(DateTime utcDate, TimeZoneInfo? timeZone = null)
+    {
+        var zone = timeZone ?? TimeZoneInfo.Local;
+        var local = utcDate.Kind == DateTimeKind.Utc
+            ? TimeZoneInfo.ConvertTimeFromUtc(utcDate, zone)
+            : TimeZoneInfo.ConvertTime(utcDate, zone);
+        return local.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Display date for a <see cref="MediaBrowser.Controller.LiveTv.LiveTvProgram"/> (air start).
+    /// </summary>
+    public static DateTime? GetProgramDisplayDateUtc(DateTime startDate)
+        => IsValidDlnaDate(startDate) ? startDate : null;
+
+    /// <summary>
+    /// Display date for a live TV channel (current programme start, or <paramref name="utcNow"/> if no EPG).
+    /// </summary>
+    public static DateTime? GetChannelDisplayDateUtc(DateTime? currentProgramStartUtc, DateTime utcNow)
+    {
+        if (currentProgramStartUtc.HasValue && IsValidDlnaDate(currentProgramStartUtc.Value))
+        {
+            return currentProgramStartUtc.Value;
+        }
+
+        return utcNow;
+    }
+
+    /// <summary>
+    /// Display date from library premiere metadata when valid.
+    /// </summary>
+    public static DateTime? GetPremiereDisplayDateUtc(DateTime? premiereDate)
+        => premiereDate.HasValue && IsValidDlnaDate(premiereDate.Value) ? premiereDate.Value : null;
+}

--- a/tests/Jellyfin.Plugin.Dlna.Tests/DlnaItemDisplayDateTests.cs
+++ b/tests/Jellyfin.Plugin.Dlna.Tests/DlnaItemDisplayDateTests.cs
@@ -1,0 +1,69 @@
+using System;
+using Jellyfin.Plugin.Dlna.Didl;
+using Xunit;
+
+namespace Jellyfin.Plugin.Dlna.Tests;
+
+public class DlnaItemDisplayDateTests
+{
+    [Theory]
+    [InlineData(1970, 1, 1)]
+    [InlineData(1970, 1, 2)]
+    [InlineData(1979, 12, 31)]
+    public void IsValidDlnaDate_RejectsEpochAndPre1980(int year, int month, int day)
+    {
+        Assert.False(DlnaItemDisplayDate.IsValidDlnaDate(new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc)));
+    }
+
+    [Theory]
+    [InlineData(1980, 1, 1)]
+    [InlineData(2024, 6, 15, 20, 30, 0)]
+    public void IsValidDlnaDate_AcceptsReasonableDates(int year, int month, int day, int hour = 0, int minute = 0, int second = 0)
+    {
+        Assert.True(DlnaItemDisplayDate.IsValidDlnaDate(new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc)));
+    }
+
+    [Fact]
+    public void IsValidDlnaDate_RejectsDefault()
+    {
+        Assert.False(DlnaItemDisplayDate.IsValidDlnaDate(default));
+    }
+
+    [Fact]
+    public void GetProgramDisplayDateUtc_UsesStartDateWhenValid()
+    {
+        var start = new DateTime(2024, 3, 10, 18, 0, 0, DateTimeKind.Utc);
+        Assert.Equal(start, DlnaItemDisplayDate.GetProgramDisplayDateUtc(start));
+    }
+
+    [Fact]
+    public void GetProgramDisplayDateUtc_ReturnsNullForEpoch()
+    {
+        Assert.Null(DlnaItemDisplayDate.GetProgramDisplayDateUtc(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
+    }
+
+    [Fact]
+    public void GetChannelDisplayDateUtc_PrefersCurrentProgramStart()
+    {
+        var programStart = new DateTime(2024, 5, 1, 12, 0, 0, DateTimeKind.Utc);
+        var now = new DateTime(2024, 5, 1, 12, 30, 0, DateTimeKind.Utc);
+
+        Assert.Equal(programStart, DlnaItemDisplayDate.GetChannelDisplayDateUtc(programStart, now));
+    }
+
+    [Fact]
+    public void GetChannelDisplayDateUtc_FallsBackToUtcNowWithoutEpg()
+    {
+        var now = new DateTime(2024, 5, 1, 12, 30, 0, DateTimeKind.Utc);
+
+        Assert.Equal(now, DlnaItemDisplayDate.GetChannelDisplayDateUtc(null, now));
+        Assert.Equal(now, DlnaItemDisplayDate.GetChannelDisplayDateUtc(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc), now));
+    }
+
+    [Fact]
+    public void FormatDlnaDateTime_UsesUtcWallTimeWhenTimeZoneSpecified()
+    {
+        var utc = new DateTime(2024, 6, 15, 14, 30, 45, DateTimeKind.Utc);
+        Assert.Equal("2024-06-15T14:30:45", DlnaItemDisplayDate.FormatDlnaDateTime(utc, TimeZoneInfo.Utc));
+    }
+}

--- a/tests/Jellyfin.Plugin.Dlna.Tests/Jellyfin.Plugin.Dlna.Tests.csproj
+++ b/tests/Jellyfin.Plugin.Dlna.Tests/Jellyfin.Plugin.Dlna.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Jellyfin.Plugin.Dlna\Jellyfin.Plugin.Dlna.csproj" />
+    <ProjectReference Include="..\..\src\Jellyfin.Plugin.Dlna.Playback\Jellyfin.Plugin.Dlna.Playback.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Some DLNA clients show `01/01/1970` for live TV because we were sending invalid epoch values in `dc:date` and missing `upnp:scheduledStartTime` / `scheduledEndTime` for channels.

This PR only changes DIDL metadata:

- use the current EPG programme start for live TV channels and programmes
- ignore invalid/epoch dates
- add scheduled start/end and channel fields when the client asks for them

## Test plan

- [x] `dotnet build`
- [x] unit tests for `DlnaItemDisplayDate`
- [ ] live TV info bar on Samsung TV shows the correct programme date

Independent of the live TV playback PR.