### PR TITLE
Add optional DLNA subtitle delivery setting

### DIFF
--- a/Jellyfin.Plugin.Dlna.sln
+++ b/Jellyfin.Plugin.Dlna.sln
@@ -14,30 +14,85 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rssdp", "src\Rssdp\Rssdp.cs
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.Dlna.Playback", "src\Jellyfin.Plugin.Dlna.Playback\Jellyfin.Plugin.Dlna.Playback.csproj", "{D5627E87-BB93-426A-B067-AE84DFAD1E84}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.Dlna.Tests", "tests\Jellyfin.Plugin.Dlna.Tests\Jellyfin.Plugin.Dlna.Tests.csproj", "{1184B1D6-F039-45C9-A65F-490529F65A2D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x64.Build.0 = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Debug|x86.Build.0 = Debug|Any CPU
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x64.ActiveCfg = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x64.Build.0 = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x86.ActiveCfg = Release|Any CPU
+		{E9649D61-9797-46E2-B1B2-D22C17066BDB}.Release|x86.Build.0 = Release|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x64.Build.0 = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Debug|x86.Build.0 = Debug|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x64.ActiveCfg = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x64.Build.0 = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x86.ActiveCfg = Release|Any CPU
+		{297324E0-E9EF-4C5A-B7AF-21CA67437D95}.Release|x86.Build.0 = Release|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x64.Build.0 = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Debug|x86.Build.0 = Debug|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x64.ActiveCfg = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x64.Build.0 = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x86.ActiveCfg = Release|Any CPU
+		{80B12BB3-24B3-47B1-93C4-5ADAF786E55B}.Release|x86.Build.0 = Release|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x64.Build.0 = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Debug|x86.Build.0 = Debug|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x64.ActiveCfg = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x64.Build.0 = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x86.ActiveCfg = Release|Any CPU
+		{D5627E87-BB93-426A-B067-AE84DFAD1E84}.Release|x86.Build.0 = Release|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Debug|x64.Build.0 = Debug|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Debug|x86.Build.0 = Debug|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Release|x64.ActiveCfg = Release|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Release|x64.Build.0 = Release|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Release|x86.ActiveCfg = Release|Any CPU
+		{1184B1D6-F039-45C9-A65F-490529F65A2D}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1184B1D6-F039-45C9-A65F-490529F65A2D} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/Jellyfin.Plugin.Dlna.Model/DlnaPluginConfigurationAccessor.cs
+++ b/src/Jellyfin.Plugin.Dlna.Model/DlnaPluginConfigurationAccessor.cs
@@ -1,0 +1,12 @@
+namespace Jellyfin.Plugin.Dlna.Model;
+
+/// <summary>
+/// Shared DLNA plugin configuration for assemblies that cannot reference the main plugin assembly.
+/// </summary>
+public static class DlnaPluginConfigurationAccessor
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether to burn in subtitles for DLNA playback.
+    /// </summary>
+    public static bool EnableSubtitleBurnIn { get; set; }
+}

--- a/src/Jellyfin.Plugin.Dlna.Model/DlnaPluginConfigurationAccessor.cs
+++ b/src/Jellyfin.Plugin.Dlna.Model/DlnaPluginConfigurationAccessor.cs
@@ -6,7 +6,7 @@ namespace Jellyfin.Plugin.Dlna.Model;
 public static class DlnaPluginConfigurationAccessor
 {
     /// <summary>
-    /// Gets or sets a value indicating whether to burn in subtitles for DLNA playback.
+    /// Gets or sets a value indicating whether to burn in subtitles for DLNA live TV playback.
     /// </summary>
     public static bool EnableSubtitleBurnIn { get; set; }
 }

--- a/src/Jellyfin.Plugin.Dlna.Playback/DlnaStreamRequestAdjustments.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/DlnaStreamRequestAdjustments.cs
@@ -1,0 +1,76 @@
+using Jellyfin.Plugin.Dlna.Model;
+using Jellyfin.Plugin.Dlna.Playback.Model;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Dlna;
+using MediaBrowser.Model.Dto;
+
+namespace Jellyfin.Plugin.Dlna.Playback;
+
+/// <summary>
+/// Adjusts DLNA stream requests once the probed media source is available.
+/// </summary>
+public static class DlnaStreamRequestAdjustments
+{
+    /// <summary>
+    /// Clears subtitle selection on browse/play-to stream info when burn-in is disabled.
+    /// </summary>
+    public static void ApplyBrowseSubtitlePreferences(StreamInfo? streamInfo)
+    {
+        if (streamInfo is null || DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn)
+        {
+            return;
+        }
+
+        streamInfo.SubtitleStreamIndex = null;
+        streamInfo.SubtitleDeliveryMethod = SubtitleDeliveryMethod.Drop;
+    }
+
+    /// <summary>
+    /// Applies or clears subtitle burn-in based on plugin configuration and the probed media source.
+    /// </summary>
+    public static void ApplySubtitleBurnInPreferences(DlnaStreamState state, MediaSourceInfo? mediaSource)
+    {
+        ApplySubtitleBurnInPreferences(state.IsVideoRequest, state.VideoRequest, mediaSource);
+
+        if (!DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn)
+        {
+            state.SubtitleStream = null;
+            state.SubtitleDeliveryMethod = SubtitleDeliveryMethod.Drop;
+        }
+    }
+
+    /// <summary>
+    /// Applies or clears subtitle burn-in based on plugin configuration and the probed media source.
+    /// </summary>
+    public static void ApplySubtitleBurnInPreferences(
+        bool isVideoRequest,
+        VideoRequestDto? videoRequest,
+        MediaSourceInfo? mediaSource)
+    {
+        if (!isVideoRequest || videoRequest is null)
+        {
+            return;
+        }
+
+        if (!DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn)
+        {
+            videoRequest.SubtitleStreamIndex = null;
+            videoRequest.SubtitleMethod = SubtitleDeliveryMethod.Drop;
+            return;
+        }
+
+        if (mediaSource is null || videoRequest.SubtitleStreamIndex.HasValue)
+        {
+            return;
+        }
+
+        var defaultIndex = mediaSource.DefaultSubtitleStreamIndex;
+        if (!defaultIndex.HasValue || defaultIndex.Value < 0)
+        {
+            return;
+        }
+
+        videoRequest.SubtitleStreamIndex = defaultIndex;
+        videoRequest.SubtitleMethod = SubtitleDeliveryMethod.Encode;
+    }
+}

--- a/src/Jellyfin.Plugin.Dlna.Playback/DlnaStreamRequestAdjustments.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/DlnaStreamRequestAdjustments.cs
@@ -12,27 +12,66 @@ namespace Jellyfin.Plugin.Dlna.Playback;
 public static class DlnaStreamRequestAdjustments
 {
     /// <summary>
-    /// Clears subtitle selection on browse/play-to stream info when burn-in is disabled.
+    /// Returns whether the media source represents a live TV stream.
     /// </summary>
-    public static void ApplyBrowseSubtitlePreferences(StreamInfo? streamInfo)
+    public static bool IsLiveTv(MediaSourceInfo? mediaSource)
+        => mediaSource?.IsInfiniteStream == true;
+
+    /// <summary>
+    /// Returns whether DLNA subtitle burn-in should be applied for the given media source.
+    /// </summary>
+    public static bool ShouldBurnInSubtitles(MediaSourceInfo? mediaSource)
+        => DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn
+           && IsLiveTv(mediaSource);
+
+    /// <summary>
+    /// Clears live TV subtitle selection on browse/play-to stream info when burn-in is disabled.
+    /// On-demand video is left on default direct-play behavior.
+    /// </summary>
+    public static void ApplyBrowseSubtitlePreferences(StreamInfo? streamInfo, MediaSourceInfo? mediaSource = null)
     {
-        if (streamInfo is null || DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn)
+        if (streamInfo is null)
         {
             return;
         }
 
-        streamInfo.SubtitleStreamIndex = null;
-        streamInfo.SubtitleDeliveryMethod = SubtitleDeliveryMethod.Drop;
+        if (mediaSource is not null)
+        {
+            if (!IsLiveTv(mediaSource))
+            {
+                return;
+            }
+
+            if (ShouldBurnInSubtitles(mediaSource))
+            {
+                return;
+            }
+
+            streamInfo.SubtitleStreamIndex = null;
+            streamInfo.SubtitleDeliveryMethod = SubtitleDeliveryMethod.Drop;
+            return;
+        }
+
+        if (!DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn)
+        {
+            streamInfo.SubtitleStreamIndex = null;
+            streamInfo.SubtitleDeliveryMethod = SubtitleDeliveryMethod.Drop;
+        }
     }
 
     /// <summary>
-    /// Applies or clears subtitle burn-in based on plugin configuration and the probed media source.
+    /// Applies or clears live TV subtitle burn-in based on plugin configuration and the probed media source.
     /// </summary>
     public static void ApplySubtitleBurnInPreferences(DlnaStreamState state, MediaSourceInfo? mediaSource)
     {
+        if (!IsLiveTv(mediaSource))
+        {
+            return;
+        }
+
         ApplySubtitleBurnInPreferences(state.IsVideoRequest, state.VideoRequest, mediaSource);
 
-        if (!DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn)
+        if (!ShouldBurnInSubtitles(mediaSource))
         {
             state.SubtitleStream = null;
             state.SubtitleDeliveryMethod = SubtitleDeliveryMethod.Drop;
@@ -40,19 +79,19 @@ public static class DlnaStreamRequestAdjustments
     }
 
     /// <summary>
-    /// Applies or clears subtitle burn-in based on plugin configuration and the probed media source.
+    /// Applies or clears live TV subtitle burn-in based on plugin configuration and the probed media source.
     /// </summary>
     public static void ApplySubtitleBurnInPreferences(
         bool isVideoRequest,
         VideoRequestDto? videoRequest,
         MediaSourceInfo? mediaSource)
     {
-        if (!isVideoRequest || videoRequest is null)
+        if (!isVideoRequest || videoRequest is null || !IsLiveTv(mediaSource))
         {
             return;
         }
 
-        if (!DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn)
+        if (!ShouldBurnInSubtitles(mediaSource))
         {
             videoRequest.SubtitleStreamIndex = null;
             videoRequest.SubtitleMethod = SubtitleDeliveryMethod.Drop;

--- a/src/Jellyfin.Plugin.Dlna.Playback/StreamingHelpers.cs
+++ b/src/Jellyfin.Plugin.Dlna.Playback/StreamingHelpers.cs
@@ -165,9 +165,13 @@ public static class StreamingHelpers
             state.DirectStreamProvider = liveStreamInfo.Item2;
         }
 
+        DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(state, mediaSource);
+
         var encodingOptions = serverConfigurationManager.GetEncodingOptions();
 
         encodingHelper.AttachMediaSourceInfo(state, encodingOptions, mediaSource, url);
+
+        DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(state, mediaSource);
 
         string? containerInternal = Path.GetExtension(state.RequestedUrl);
 

--- a/src/Jellyfin.Plugin.Dlna/Configuration/DlnaPluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.Dlna/Configuration/DlnaPluginConfiguration.cs
@@ -40,8 +40,8 @@ public class DlnaPluginConfiguration : BasePluginConfiguration
     public Guid? DefaultUserId { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to burn in subtitles for DLNA playback
-    /// (including live TV) using the default user's subtitle preferences.
+    /// Gets or sets a value indicating whether to burn in subtitles for DLNA live TV playback
+    /// using the default user's subtitle preferences.
     /// </summary>
     public bool EnableSubtitleBurnIn { get; set; } = false;
 }

--- a/src/Jellyfin.Plugin.Dlna/Configuration/DlnaPluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.Dlna/Configuration/DlnaPluginConfiguration.cs
@@ -38,4 +38,10 @@ public class DlnaPluginConfiguration : BasePluginConfiguration
     /// Gets or sets the default user account that the dlna server uses.
     /// </summary>
     public Guid? DefaultUserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to burn in subtitles for DLNA playback
+    /// (including live TV) using the default user's subtitle preferences.
+    /// </summary>
+    public bool EnableSubtitleBurnIn { get; set; } = false;
 }

--- a/src/Jellyfin.Plugin.Dlna/Configuration/config.html
+++ b/src/Jellyfin.Plugin.Dlna/Configuration/config.html
@@ -53,19 +53,24 @@
 
                         <div class="selectContainer">
                             <select is="emby-select" id="dlnaSelectUser" label="Default User:"></select>
+                            <div class="fieldDescription">
+                                Select the Jellyfin user whose library access and subtitle preferences are used for DLNA playback.
+                                A default user is required for live TV subtitle burn-in.
+                            </div>
                         </div>
 
                         <div class="inputContainer">
                             <div class="checkboxContainer">
                                 <label>
                                     <input type="checkbox" is="emby-checkbox" id="dlnaSubtitleBurnIn" />
-                                    <span>Burn in subtitles for DLNA playback</span>
+                                    <span>Burn in subtitles for DLNA live TV</span>
                                 </label>
                             </div>
                             <div class="fieldDescription">
-                                Burns subtitles into the video stream using the default user's subtitle language and mode.
-                                Requires transcoding and may increase CPU or GPU usage.
-                                When disabled, Jellyfin does not send DLNA subtitle tracks (burned-in or external).
+                                Burns subtitles into live TV streams using the default user's subtitle language and mode.
+                                Requires a default user to be selected above. Requires transcoding and may increase CPU or GPU usage.
+                                Does not apply to movies or other on-demand content.
+                                When disabled, Jellyfin does not send DLNA subtitle tracks for live TV (burned-in or external).
                                 Some live TV broadcasts may still show subtitles decoded by the TV from the stream.
                             </div>
                         </div>

--- a/src/Jellyfin.Plugin.Dlna/Configuration/config.html
+++ b/src/Jellyfin.Plugin.Dlna/Configuration/config.html
@@ -54,6 +54,21 @@
                         <div class="selectContainer">
                             <select is="emby-select" id="dlnaSelectUser" label="Default User:"></select>
                         </div>
+
+                        <div class="inputContainer">
+                            <div class="checkboxContainer">
+                                <label>
+                                    <input type="checkbox" is="emby-checkbox" id="dlnaSubtitleBurnIn" />
+                                    <span>Burn in subtitles for DLNA playback</span>
+                                </label>
+                            </div>
+                            <div class="fieldDescription">
+                                Burns subtitles into the video stream using the default user's subtitle language and mode.
+                                Requires transcoding and may increase CPU or GPU usage.
+                                When disabled, Jellyfin does not send DLNA subtitle tracks (burned-in or external).
+                                Some live TV broadcasts may still show subtitles decoded by the TV from the stream.
+                            </div>
+                        </div>
                     </div>
                     <div>
                         <button is="emby-button" type="submit" data-theme="b" class="raised button-submit block">

--- a/src/Jellyfin.Plugin.Dlna/Configuration/config.js
+++ b/src/Jellyfin.Plugin.Dlna/Configuration/config.js
@@ -10,6 +10,7 @@ const DlnaConfigurationPage = {
                 page.querySelector('#dlnaBlastAlive').checked = config.BlastAliveMessages;
                 page.querySelector('#dlnaAliveInterval').value = parseInt(config.AliveMessageIntervalSeconds) || this.defaultAliveInterval;
                 page.querySelector('#dlnaMatchedHost').checked = config.SendOnlyMatchedHost;
+                page.querySelector('#dlnaSubtitleBurnIn').checked = config.EnableSubtitleBurnIn === true;
 
                 ApiClient.getUsers()
                     .then(function(users){
@@ -44,6 +45,7 @@ const DlnaConfigurationPage = {
                     
                     let selectedUser = page.querySelector('#dlnaSelectUser').value;
                     config.DefaultUserId = selectedUser.length > 0 ? selectedUser : null;
+                    config.EnableSubtitleBurnIn = page.querySelector('#dlnaSubtitleBurnIn').checked;
 
                     ApiClient.updatePluginConfiguration(DlnaConfigurationPage.pluginUniqueId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });

--- a/src/Jellyfin.Plugin.Dlna/Configuration/config.js
+++ b/src/Jellyfin.Plugin.Dlna/Configuration/config.js
@@ -33,6 +33,14 @@ const DlnaConfigurationPage = {
         page.querySelector('#dlnaSelectUser').value = selectedId;
     },
     save: function(page) {
+        const subtitleBurnIn = page.querySelector('#dlnaSubtitleBurnIn').checked;
+        const selectedUser = page.querySelector('#dlnaSelectUser').value;
+
+        if (subtitleBurnIn && !selectedUser) {
+            Dashboard.alert('Select a default user before enabling live TV subtitle burn-in.');
+            return Promise.resolve();
+        }
+
         Dashboard.showLoadingMsg();
         return new Promise((_) => {
             ApiClient.getPluginConfiguration(this.pluginUniqueId)
@@ -42,10 +50,9 @@ const DlnaConfigurationPage = {
                     config.BlastAliveMessages = page.querySelector('#dlnaBlastAlive').checked;
                     config.AliveMessageIntervalSeconds = parseInt(page.querySelector('#dlnaAliveInterval').value) || this.defaultAliveInterval;
                     config.SendOnlyMatchedHost = page.querySelector('#dlnaMatchedHost').checked;
-                    
-                    let selectedUser = page.querySelector('#dlnaSelectUser').value;
+
                     config.DefaultUserId = selectedUser.length > 0 ? selectedUser : null;
-                    config.EnableSubtitleBurnIn = page.querySelector('#dlnaSubtitleBurnIn').checked;
+                    config.EnableSubtitleBurnIn = subtitleBurnIn;
 
                     ApiClient.updatePluginConfiguration(DlnaConfigurationPage.pluginUniqueId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });

--- a/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
@@ -9,6 +9,7 @@ using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.Dlna.ContentDirectory;
 using Jellyfin.Plugin.Dlna.Extensions;
 using Jellyfin.Plugin.Dlna.Model;
+using Jellyfin.Plugin.Dlna.Playback;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Entities;
@@ -253,6 +254,8 @@ public class DidlBuilder
                 DeviceId = deviceId,
                 MaxBitrate = _profile.MaxStreamingBitrate
             }) ?? throw new InvalidOperationException("No optimal video stream found");
+
+            DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo);
         }
 
         var targetWidth = streamInfo.TargetWidth;
@@ -290,6 +293,11 @@ public class DidlBuilder
         foreach (var contentFeature in contentFeatureList)
         {
             AddVideoResource(writer, filter, contentFeature, streamInfo);
+        }
+
+        if (!DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn)
+        {
+            return;
         }
 
         var subtitleProfiles = streamInfo.GetSubtitleProfiles(_mediaEncoder, false, _serverAddress, _accessToken);

--- a/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
@@ -246,16 +246,19 @@ public class DidlBuilder
         {
             var sources = _mediaSourceManager.GetStaticMediaSources(video, true, _user);
 
+            var mediaSources = sources.ToArray();
+            var browseMediaSource = mediaSources.FirstOrDefault(s => s.IsInfiniteStream) ?? mediaSources.FirstOrDefault();
+
             streamInfo = new StreamBuilder(_mediaEncoder, _logger).GetOptimalVideoStream(new MediaOptions
             {
                 ItemId = video.Id,
-                MediaSources = sources.ToArray(),
+                MediaSources = mediaSources,
                 Profile = _profile,
                 DeviceId = deviceId,
                 MaxBitrate = _profile.MaxStreamingBitrate
             }) ?? throw new InvalidOperationException("No optimal video stream found");
 
-            DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo);
+            DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo, browseMediaSource);
         }
 
         var targetWidth = streamInfo.TargetWidth;

--- a/src/Jellyfin.Plugin.Dlna/DlnaPlugin.cs
+++ b/src/Jellyfin.Plugin.Dlna/DlnaPlugin.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.Dlna.Configuration;
+using Jellyfin.Plugin.Dlna.Model;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
@@ -27,6 +28,19 @@ public class DlnaPlugin : BasePlugin<DlnaPluginConfiguration>, IHasWebPages
         : base(applicationPaths, xmlSerializer)
     {
         Instance = this;
+        SyncConfigurationAccessor();
+    }
+
+    /// <inheritdoc />
+    public override void UpdateConfiguration(BasePluginConfiguration configuration)
+    {
+        base.UpdateConfiguration(configuration);
+        SyncConfigurationAccessor();
+    }
+
+    private static void SyncConfigurationAccessor()
+    {
+        DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = Instance.Configuration.EnableSubtitleBurnIn;
     }
 
     /// <inheritdoc />

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
@@ -11,6 +11,7 @@ using Jellyfin.Extensions;
 using Jellyfin.Plugin.Dlna.Didl;
 using Jellyfin.Plugin.Dlna.Extensions;
 using Jellyfin.Plugin.Dlna.Model;
+using Jellyfin.Plugin.Dlna.Playback;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -626,22 +627,7 @@ public class PlayToSession : ISessionController, IDisposable
     private PlaylistItem GetPlaylistItem(BaseItem item, MediaSourceInfo[] mediaSources, DlnaDeviceProfile profile, string deviceId, string? mediaSourceId, int? audioStreamIndex, int? subtitleStreamIndex)
         => item.MediaType switch
         {
-            MediaType.Video => new PlaylistItem
-            {
-                StreamInfo = new StreamBuilder(_mediaEncoder, _logger).GetOptimalVideoStream(new MediaOptions
-                {
-                    ItemId = item.Id,
-                    MediaSources = mediaSources,
-                    Profile = profile,
-                    DeviceId = deviceId,
-                    MaxBitrate = profile.MaxStreamingBitrate,
-                    MediaSourceId = mediaSourceId,
-                    AudioStreamIndex = audioStreamIndex,
-                    SubtitleStreamIndex = subtitleStreamIndex,
-                    EnableDirectStream = false
-                }),
-                Profile = profile
-            },
+            MediaType.Video => CreateVideoPlaylistItem(item, mediaSources, profile, deviceId, mediaSourceId, audioStreamIndex, subtitleStreamIndex),
             MediaType.Audio => new PlaylistItem
             {
                 StreamInfo = new StreamBuilder(_mediaEncoder, _logger).GetOptimalAudioStream(new MediaOptions
@@ -658,6 +644,37 @@ public class PlayToSession : ISessionController, IDisposable
             MediaType.Photo => PlaylistItemFactory.Create((Photo)item, profile),
             _ => throw new ArgumentException("Unrecognized item type.")
         };
+
+    private PlaylistItem CreateVideoPlaylistItem(
+        BaseItem item,
+        MediaSourceInfo[] mediaSources,
+        DlnaDeviceProfile profile,
+        string deviceId,
+        string? mediaSourceId,
+        int? audioStreamIndex,
+        int? subtitleStreamIndex)
+    {
+        var streamInfo = new StreamBuilder(_mediaEncoder, _logger).GetOptimalVideoStream(new MediaOptions
+        {
+            ItemId = item.Id,
+            MediaSources = mediaSources,
+            Profile = profile,
+            DeviceId = deviceId,
+            MaxBitrate = profile.MaxStreamingBitrate,
+            MediaSourceId = mediaSourceId,
+            AudioStreamIndex = audioStreamIndex,
+            SubtitleStreamIndex = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn ? subtitleStreamIndex : null,
+            EnableDirectStream = false
+        });
+
+        DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo);
+
+        return new PlaylistItem
+        {
+            StreamInfo = streamInfo,
+            Profile = profile
+        };
+    }
 
     /// <summary>
     /// Plays the items.

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
@@ -654,6 +654,9 @@ public class PlayToSession : ISessionController, IDisposable
         int? audioStreamIndex,
         int? subtitleStreamIndex)
     {
+        var mediaSource = mediaSources.FirstOrDefault(s => string.Equals(s.Id, mediaSourceId, StringComparison.OrdinalIgnoreCase))
+            ?? mediaSources.FirstOrDefault(s => s.IsInfiniteStream)
+            ?? mediaSources.FirstOrDefault();
         var streamInfo = new StreamBuilder(_mediaEncoder, _logger).GetOptimalVideoStream(new MediaOptions
         {
             ItemId = item.Id,
@@ -663,11 +666,13 @@ public class PlayToSession : ISessionController, IDisposable
             MaxBitrate = profile.MaxStreamingBitrate,
             MediaSourceId = mediaSourceId,
             AudioStreamIndex = audioStreamIndex,
-            SubtitleStreamIndex = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn ? subtitleStreamIndex : null,
+            SubtitleStreamIndex = mediaSource?.IsInfiniteStream == true && DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn
+                ? subtitleStreamIndex
+                : null,
             EnableDirectStream = false
         });
 
-        DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo);
+        DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo, mediaSource);
 
         return new PlaylistItem
         {

--- a/tests/Jellyfin.Plugin.Dlna.Tests/DlnaPluginConfigurationTests.cs
+++ b/tests/Jellyfin.Plugin.Dlna.Tests/DlnaPluginConfigurationTests.cs
@@ -1,0 +1,13 @@
+using Jellyfin.Plugin.Dlna.Configuration;
+using Xunit;
+
+namespace Jellyfin.Plugin.Dlna.Tests;
+
+public class DlnaPluginConfigurationTests
+{
+    [Fact]
+    public void EnableSubtitleBurnIn_DefaultsToFalse()
+    {
+        Assert.False(new DlnaPluginConfiguration().EnableSubtitleBurnIn);
+    }
+}

--- a/tests/Jellyfin.Plugin.Dlna.Tests/DlnaStreamRequestAdjustmentsTests.cs
+++ b/tests/Jellyfin.Plugin.Dlna.Tests/DlnaStreamRequestAdjustmentsTests.cs
@@ -3,6 +3,7 @@ using Jellyfin.Plugin.Dlna.Playback;
 using MediaBrowser.Controller.Streaming;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
 using StreamInfo = MediaBrowser.Model.Dlna.StreamInfo;
 using Xunit;
 
@@ -11,15 +12,37 @@ namespace Jellyfin.Plugin.Dlna.Tests;
 public class DlnaStreamRequestAdjustmentsTests
 {
     [Fact]
-    public void ApplyBrowseSubtitlePreferences_LeavesStreamInfoWhenEnabled()
+    public void ShouldBurnInSubtitles_RequiresEnabledLiveTvSource()
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = true;
+
+            Assert.True(DlnaStreamRequestAdjustments.ShouldBurnInSubtitles(new MediaSourceInfo { IsInfiniteStream = true }));
+            Assert.False(DlnaStreamRequestAdjustments.ShouldBurnInSubtitles(new MediaSourceInfo { IsInfiniteStream = false }));
+            Assert.False(DlnaStreamRequestAdjustments.ShouldBurnInSubtitles(null));
+
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = false;
+            Assert.False(DlnaStreamRequestAdjustments.ShouldBurnInSubtitles(new MediaSourceInfo { IsInfiniteStream = true }));
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+
+    [Fact]
+    public void ApplyBrowseSubtitlePreferences_LeavesStreamInfoForLiveTvWhenEnabled()
     {
         var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
         try
         {
             DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = true;
             var streamInfo = new StreamInfo { DeviceProfile = new DeviceProfile(), SubtitleStreamIndex = 2 };
+            var mediaSource = new MediaSourceInfo { IsInfiniteStream = true };
 
-            DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo);
+            DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo, mediaSource);
 
             Assert.Equal(2, streamInfo.SubtitleStreamIndex);
         }
@@ -30,15 +53,43 @@ public class DlnaStreamRequestAdjustmentsTests
     }
 
     [Fact]
-    public void ApplyBrowseSubtitlePreferences_ClearsStreamInfoWhenDisabled()
+    public void ApplyBrowseSubtitlePreferences_LeavesMoviesUntouched()
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = true;
+            var streamInfo = new StreamInfo { DeviceProfile = new DeviceProfile(), SubtitleStreamIndex = 2 };
+            var mediaSource = new MediaSourceInfo
+            {
+                IsInfiniteStream = false,
+                MediaStreams =
+                [
+                    new MediaStream { Type = MediaStreamType.Subtitle, Index = 2, Language = "ron", IsTextSubtitleStream = true }
+                ]
+            };
+
+            DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo, mediaSource);
+
+            Assert.Equal(2, streamInfo.SubtitleStreamIndex);
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+
+    [Fact]
+    public void ApplyBrowseSubtitlePreferences_ClearsLiveTvWhenBurnInDisabled()
     {
         var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
         try
         {
             DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = false;
             var streamInfo = new StreamInfo { DeviceProfile = new DeviceProfile(), SubtitleStreamIndex = 2 };
+            var mediaSource = new MediaSourceInfo { IsInfiniteStream = true };
 
-            DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo);
+            DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo, mediaSource);
 
             Assert.Null(streamInfo.SubtitleStreamIndex);
             Assert.Equal(SubtitleDeliveryMethod.Drop, streamInfo.SubtitleDeliveryMethod);
@@ -50,7 +101,34 @@ public class DlnaStreamRequestAdjustmentsTests
     }
 
     [Fact]
-    public void ApplySubtitleBurnInPreferences_ClearsExistingIndexWhenDisabled()
+    public void ApplyBrowseSubtitlePreferences_LeavesMoviesUntouchedWhenBurnInDisabled()
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = false;
+            var streamInfo = new StreamInfo { DeviceProfile = new DeviceProfile(), SubtitleStreamIndex = 2 };
+            var mediaSource = new MediaSourceInfo
+            {
+                IsInfiniteStream = false,
+                MediaStreams =
+                [
+                    new MediaStream { Type = MediaStreamType.Subtitle, Index = 2, Language = "ron", IsTextSubtitleStream = true }
+                ]
+            };
+
+            DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo, mediaSource);
+
+            Assert.Equal(2, streamInfo.SubtitleStreamIndex);
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+
+    [Fact]
+    public void ApplySubtitleBurnInPreferences_LeavesMoviesUntouchedWhenDisabled()
     {
         var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
         try
@@ -62,10 +140,10 @@ public class DlnaStreamRequestAdjustmentsTests
                 SubtitleMethod = SubtitleDeliveryMethod.Encode
             };
 
-            DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, new MediaSourceInfo());
+            DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, new MediaSourceInfo { IsInfiniteStream = false });
 
-            Assert.Null(request.SubtitleStreamIndex);
-            Assert.Equal(SubtitleDeliveryMethod.Drop, request.SubtitleMethod);
+            Assert.Equal(2, request.SubtitleStreamIndex);
+            Assert.Equal(SubtitleDeliveryMethod.Encode, request.SubtitleMethod);
         }
         finally
         {
@@ -74,7 +152,7 @@ public class DlnaStreamRequestAdjustmentsTests
     }
 
     [Fact]
-    public void ApplySubtitleBurnInPreferences_DoesNothingWhenDisabledAndNoIndex()
+    public void ApplySubtitleBurnInPreferences_DoesNothingWhenDisabledAndNoIndexForLiveTv()
     {
         var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
         try
@@ -82,7 +160,7 @@ public class DlnaStreamRequestAdjustmentsTests
             DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = false;
             var request = new VideoRequestDto();
 
-            DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, new MediaSourceInfo());
+            DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, new MediaSourceInfo { IsInfiniteStream = true });
 
             Assert.Null(request.SubtitleStreamIndex);
         }
@@ -93,14 +171,14 @@ public class DlnaStreamRequestAdjustmentsTests
     }
 
     [Fact]
-    public void ApplySubtitleBurnInPreferences_SetsEncodeWhenEnabledAndDefaultIndexPresent()
+    public void ApplySubtitleBurnInPreferences_SetsEncodeWhenEnabledForLiveTvAndDefaultIndexPresent()
     {
         var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
         try
         {
             DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = true;
             var request = new VideoRequestDto();
-            var mediaSource = new MediaSourceInfo { DefaultSubtitleStreamIndex = 2 };
+            var mediaSource = new MediaSourceInfo { DefaultSubtitleStreamIndex = 2, IsInfiniteStream = true };
 
             DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, mediaSource);
 
@@ -114,7 +192,57 @@ public class DlnaStreamRequestAdjustmentsTests
     }
 
     [Fact]
-    public void ApplySubtitleBurnInPreferences_DoesNotOverrideExistingIndexWhenEnabled()
+    public void ApplySubtitleBurnInPreferences_LeavesMoviesUntouchedWhenEnabled()
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = true;
+            var request = new VideoRequestDto
+            {
+                SubtitleStreamIndex = 2,
+                SubtitleMethod = SubtitleDeliveryMethod.Embed
+            };
+            var mediaSource = new MediaSourceInfo { DefaultSubtitleStreamIndex = 2, IsInfiniteStream = false };
+
+            DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, mediaSource);
+
+            Assert.Equal(2, request.SubtitleStreamIndex);
+            Assert.Equal(SubtitleDeliveryMethod.Embed, request.SubtitleMethod);
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+
+    [Fact]
+    public void ApplySubtitleBurnInPreferences_ClearsLiveTvWhenBurnInDisabled()
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = false;
+            var request = new VideoRequestDto
+            {
+                SubtitleStreamIndex = 2,
+                SubtitleMethod = SubtitleDeliveryMethod.Encode
+            };
+            var mediaSource = new MediaSourceInfo { DefaultSubtitleStreamIndex = 2, IsInfiniteStream = true };
+
+            DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, mediaSource);
+
+            Assert.Null(request.SubtitleStreamIndex);
+            Assert.Equal(SubtitleDeliveryMethod.Drop, request.SubtitleMethod);
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+
+    [Fact]
+    public void ApplySubtitleBurnInPreferences_DoesNotOverrideExistingIndexWhenEnabledForLiveTv()
     {
         var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
         try
@@ -125,7 +253,7 @@ public class DlnaStreamRequestAdjustmentsTests
                 SubtitleStreamIndex = 5,
                 SubtitleMethod = SubtitleDeliveryMethod.Embed
             };
-            var mediaSource = new MediaSourceInfo { DefaultSubtitleStreamIndex = 2 };
+            var mediaSource = new MediaSourceInfo { DefaultSubtitleStreamIndex = 2, IsInfiniteStream = true };
 
             DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, mediaSource);
 
@@ -141,14 +269,14 @@ public class DlnaStreamRequestAdjustmentsTests
     [Theory]
     [InlineData(null)]
     [InlineData(-1)]
-    public void ApplySubtitleBurnInPreferences_IgnoresMissingDefaultIndexWhenEnabled(int? defaultIndex)
+    public void ApplySubtitleBurnInPreferences_IgnoresMissingDefaultIndexWhenEnabledForLiveTv(int? defaultIndex)
     {
         var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
         try
         {
             DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = true;
             var request = new VideoRequestDto();
-            var mediaSource = new MediaSourceInfo { DefaultSubtitleStreamIndex = defaultIndex };
+            var mediaSource = new MediaSourceInfo { DefaultSubtitleStreamIndex = defaultIndex, IsInfiniteStream = true };
 
             DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, mediaSource);
 

--- a/tests/Jellyfin.Plugin.Dlna.Tests/DlnaStreamRequestAdjustmentsTests.cs
+++ b/tests/Jellyfin.Plugin.Dlna.Tests/DlnaStreamRequestAdjustmentsTests.cs
@@ -1,0 +1,162 @@
+using Jellyfin.Plugin.Dlna.Model;
+using Jellyfin.Plugin.Dlna.Playback;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Dlna;
+using MediaBrowser.Model.Dto;
+using StreamInfo = MediaBrowser.Model.Dlna.StreamInfo;
+using Xunit;
+
+namespace Jellyfin.Plugin.Dlna.Tests;
+
+public class DlnaStreamRequestAdjustmentsTests
+{
+    [Fact]
+    public void ApplyBrowseSubtitlePreferences_LeavesStreamInfoWhenEnabled()
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = true;
+            var streamInfo = new StreamInfo { DeviceProfile = new DeviceProfile(), SubtitleStreamIndex = 2 };
+
+            DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo);
+
+            Assert.Equal(2, streamInfo.SubtitleStreamIndex);
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+
+    [Fact]
+    public void ApplyBrowseSubtitlePreferences_ClearsStreamInfoWhenDisabled()
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = false;
+            var streamInfo = new StreamInfo { DeviceProfile = new DeviceProfile(), SubtitleStreamIndex = 2 };
+
+            DlnaStreamRequestAdjustments.ApplyBrowseSubtitlePreferences(streamInfo);
+
+            Assert.Null(streamInfo.SubtitleStreamIndex);
+            Assert.Equal(SubtitleDeliveryMethod.Drop, streamInfo.SubtitleDeliveryMethod);
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+
+    [Fact]
+    public void ApplySubtitleBurnInPreferences_ClearsExistingIndexWhenDisabled()
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = false;
+            var request = new VideoRequestDto
+            {
+                SubtitleStreamIndex = 2,
+                SubtitleMethod = SubtitleDeliveryMethod.Encode
+            };
+
+            DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, new MediaSourceInfo());
+
+            Assert.Null(request.SubtitleStreamIndex);
+            Assert.Equal(SubtitleDeliveryMethod.Drop, request.SubtitleMethod);
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+
+    [Fact]
+    public void ApplySubtitleBurnInPreferences_DoesNothingWhenDisabledAndNoIndex()
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = false;
+            var request = new VideoRequestDto();
+
+            DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, new MediaSourceInfo());
+
+            Assert.Null(request.SubtitleStreamIndex);
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+
+    [Fact]
+    public void ApplySubtitleBurnInPreferences_SetsEncodeWhenEnabledAndDefaultIndexPresent()
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = true;
+            var request = new VideoRequestDto();
+            var mediaSource = new MediaSourceInfo { DefaultSubtitleStreamIndex = 2 };
+
+            DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, mediaSource);
+
+            Assert.Equal(2, request.SubtitleStreamIndex);
+            Assert.Equal(SubtitleDeliveryMethod.Encode, request.SubtitleMethod);
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+
+    [Fact]
+    public void ApplySubtitleBurnInPreferences_DoesNotOverrideExistingIndexWhenEnabled()
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = true;
+            var request = new VideoRequestDto
+            {
+                SubtitleStreamIndex = 5,
+                SubtitleMethod = SubtitleDeliveryMethod.Embed
+            };
+            var mediaSource = new MediaSourceInfo { DefaultSubtitleStreamIndex = 2 };
+
+            DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, mediaSource);
+
+            Assert.Equal(5, request.SubtitleStreamIndex);
+            Assert.Equal(SubtitleDeliveryMethod.Embed, request.SubtitleMethod);
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(-1)]
+    public void ApplySubtitleBurnInPreferences_IgnoresMissingDefaultIndexWhenEnabled(int? defaultIndex)
+    {
+        var previous = DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn;
+        try
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = true;
+            var request = new VideoRequestDto();
+            var mediaSource = new MediaSourceInfo { DefaultSubtitleStreamIndex = defaultIndex };
+
+            DlnaStreamRequestAdjustments.ApplySubtitleBurnInPreferences(true, request, mediaSource);
+
+            Assert.Null(request.SubtitleStreamIndex);
+        }
+        finally
+        {
+            DlnaPluginConfigurationAccessor.EnableSubtitleBurnIn = previous;
+        }
+    }
+}

--- a/tests/Jellyfin.Plugin.Dlna.Tests/Jellyfin.Plugin.Dlna.Tests.csproj
+++ b/tests/Jellyfin.Plugin.Dlna.Tests/Jellyfin.Plugin.Dlna.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Jellyfin.Plugin.Dlna\Jellyfin.Plugin.Dlna.csproj" />
+    <ProjectReference Include="..\..\src\Jellyfin.Plugin.Dlna.Playback\Jellyfin.Plugin.Dlna.Playback.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
DLNA clients often ignore Jellyfin subtitle URLs, and burning subtitles into live TV requires transcoding. I wanted a way to leave subtitles off by default and opt in when needed.

This PR adds `EnableSubtitleBurnIn` (default **off**) in the plugin settings:

- **off:** no external subtitle tracks in DIDL, subtitle indices cleared from browse/play URLs, delivery set to `Drop`
- **on:** when the client omits `SubtitleStreamIndex`, use the default user's subtitle language/mode with burn-in (`Encode`)

Broadcast DVB subtitles in the transport stream are unchanged; the TV may still decode those on its own.

## Test plan

- [x] `dotnet build`
- [x] unit tests for subtitle preference handling and the default config value
- [ ] with setting off: no Jellyfin-managed DLNA subtitles
- [ ] with setting on and default user subtitles configured: burn-in works on live TV

Independent of the live TV playback PR. If both land, `DlnaPluginConfigurationAccessor` and `DlnaStreamRequestAdjustments` will need a trivial merge to combine properties/methods.