### PR TITLE
Update matching for Denon AVR and DRA receivers

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/Profiles/Xml/Denon AVR.xml
+++ b/src/Jellyfin.Plugin.Dlna/Profiles/Xml/Denon AVR.xml
@@ -3,7 +3,7 @@
   xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>Denon AVR</Name>
   <Identification>
-    <FriendlyName>Denon:\[AVR:.*</FriendlyName>
+    <FriendlyName>^Denon..?(?:AVR|DRA)-.*$</FriendlyName>
     <Manufacturer>Denon</Manufacturer>
     <Headers />
   </Identification>


### PR DESCRIPTION
This PR updates the `FriendlyName` identification for Denon receivers so they not only match the Denon AVR series, but also the Denon DRA series - which are two-channel receivers built on the same platform. I have tested this with my DRA-800H.