### PR TITLE
Add alphabetical folders for movies and series

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -83,7 +83,8 @@ public class ControlHandler : BaseControlHandler
         IMediaSourceManager mediaSourceManager,
         IUserViewManager userViewManager,
         IMediaEncoder mediaEncoder,
-        ITVSeriesManager tvSeriesManager)
+        ITVSeriesManager tvSeriesManager
+    )
         : base(logger)
     {
         _libraryManager = libraryManager;
@@ -105,11 +106,16 @@ public class ControlHandler : BaseControlHandler
             mediaSourceManager,
             Logger,
             mediaEncoder,
-            libraryManager);
+            libraryManager
+        );
     }
 
     /// <inheritdoc />
-    protected override void WriteResult(string methodName, IReadOnlyDictionary<string, string> methodParams, XmlWriter xmlWriter)
+    protected override void WriteResult(
+        string methodName,
+        IReadOnlyDictionary<string, string> methodParams,
+        XmlWriter xmlWriter
+    )
     {
         ArgumentNullException.ThrowIfNull(xmlWriter);
         ArgumentNullException.ThrowIfNull(methodParams);
@@ -128,7 +134,13 @@ public class ControlHandler : BaseControlHandler
             return;
         }
 
-        if (string.Equals(methodName, "GetSortExtensionCapabilities", StringComparison.OrdinalIgnoreCase))
+        if (
+            string.Equals(
+                methodName,
+                "GetSortExtensionCapabilities",
+                StringComparison.OrdinalIgnoreCase
+            )
+        )
         {
             HandleGetSortExtensionCapabilities(xmlWriter);
             return;
@@ -207,7 +219,8 @@ public class ControlHandler : BaseControlHandler
             item,
             userdata,
             UserDataSaveReason.TogglePlayed,
-            CancellationToken.None);
+            CancellationToken.None
+        );
     }
 
     /// <summary>
@@ -218,7 +231,8 @@ public class ControlHandler : BaseControlHandler
     {
         xmlWriter.WriteElementString(
             "SearchCaps",
-            "res@resolution,res@size,res@duration,dc:title,dc:creator,upnp:actor,upnp:artist,upnp:genre,upnp:album,dc:date,upnp:class,@id,@refID,@protocolInfo,upnp:author,dc:description,pv:avKeywords");
+            "res@resolution,res@size,res@duration,dc:title,dc:creator,upnp:actor,upnp:artist,upnp:genre,upnp:album,dc:date,upnp:class,@id,@refID,@protocolInfo,upnp:author,dc:description,pv:avKeywords"
+        );
     }
 
     /// <summary>
@@ -229,7 +243,8 @@ public class ControlHandler : BaseControlHandler
     {
         xmlWriter.WriteElementString(
             "SortCaps",
-            "res@duration,res@size,res@bitrate,dc:date,dc:title,dc:size,upnp:album,upnp:artist,upnp:albumArtist,upnp:episodeNumber,upnp:genre,upnp:originalTrackNumber,upnp:rating");
+            "res@duration,res@size,res@bitrate,dc:date,dc:title,dc:size,upnp:album,upnp:artist,upnp:albumArtist,upnp:episodeNumber,upnp:genre,upnp:originalTrackNumber,upnp:rating"
+        );
     }
 
     /// <summary>
@@ -240,7 +255,8 @@ public class ControlHandler : BaseControlHandler
     {
         xmlWriter.WriteElementString(
             "SortExtensionCaps",
-            "res@duration,res@size,res@bitrate,dc:date,dc:title,dc:size,upnp:album,upnp:artist,upnp:albumArtist,upnp:episodeNumber,upnp:genre,upnp:originalTrackNumber,upnp:rating");
+            "res@duration,res@size,res@bitrate,dc:date,dc:title,dc:size,upnp:album,upnp:artist,upnp:albumArtist,upnp:episodeNumber,upnp:genre,upnp:originalTrackNumber,upnp:rating"
+        );
     }
 
     /// <summary>
@@ -265,8 +281,8 @@ public class ControlHandler : BaseControlHandler
     /// Adds the "FeatureList" element to the xml document.
     /// </summary>
     /// <param name="xmlWriter">The <see cref="XmlWriter"/>.</param>
-    private static void HandleXGetFeatureList(XmlWriter xmlWriter)
-        => HandleGetFeatureList(xmlWriter);
+    private static void HandleXGetFeatureList(XmlWriter xmlWriter) =>
+        HandleGetFeatureList(xmlWriter);
 
     /// <summary>
     /// Builds a static feature list.
@@ -275,13 +291,13 @@ public class ControlHandler : BaseControlHandler
     private static string WriteFeatureListXml()
     {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-               + "<Features xmlns=\"urn:schemas-upnp-org:av:avs\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"urn:schemas-upnp-org:av:avs http://www.upnp.org/schemas/av/avs.xsd\">"
-               + "<Feature name=\"samsung.com_BASICVIEW\" version=\"1\">"
-               + "<container id=\"0\" type=\"object.item.imageItem\"/>"
-               + "<container id=\"0\" type=\"object.item.audioItem\"/>"
-               + "<container id=\"0\" type=\"object.item.videoItem\"/>"
-               + "</Feature>"
-               + "</Features>";
+            + "<Features xmlns=\"urn:schemas-upnp-org:av:avs\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"urn:schemas-upnp-org:av:avs http://www.upnp.org/schemas/av/avs.xsd\">"
+            + "<Feature name=\"samsung.com_BASICVIEW\" version=\"1\">"
+            + "<container id=\"0\" type=\"object.item.imageItem\"/>"
+            + "<container id=\"0\" type=\"object.item.audioItem\"/>"
+            + "<container id=\"0\" type=\"object.item.videoItem\"/>"
+            + "</Feature>"
+            + "</Features>";
     }
 
     /// <summary>
@@ -290,12 +306,18 @@ public class ControlHandler : BaseControlHandler
     /// <param name="xmlWriter">The <see cref="XmlWriter"/>.</param>
     /// <param name="sparams">The method parameters.</param>
     /// <param name="deviceId">The device Id to use.</param>
-    private void HandleBrowse(XmlWriter xmlWriter, IReadOnlyDictionary<string, string> sparams, string deviceId)
+    private void HandleBrowse(
+        XmlWriter xmlWriter,
+        IReadOnlyDictionary<string, string> sparams,
+        string deviceId
+    )
     {
         var id = sparams["ObjectID"];
         var flag = sparams["BrowseFlag"];
         var filter = new Filter(sparams.GetValueOrDefault("Filter", "*"));
-        var sortCriteria = new SortCriteria(sparams.GetValueOrDefault("SortCriteria", string.Empty));
+        var sortCriteria = new SortCriteria(
+            sparams.GetValueOrDefault("SortCriteria", string.Empty)
+        );
 
         var provided = 0;
 
@@ -304,12 +326,20 @@ public class ControlHandler : BaseControlHandler
         int? requestedCount = null;
         int? start = 0;
 
-        if (sparams.ContainsKey("RequestedCount") && int.TryParse(sparams["RequestedCount"], out var requestedVal) && requestedVal > 0)
+        if (
+            sparams.ContainsKey("RequestedCount")
+            && int.TryParse(sparams["RequestedCount"], out var requestedVal)
+            && requestedVal > 0
+        )
         {
             requestedCount = requestedVal;
         }
 
-        if (sparams.ContainsKey("StartingIndex") && int.TryParse(sparams["StartingIndex"], out var startVal) && startVal > 0)
+        if (
+            sparams.ContainsKey("StartingIndex")
+            && int.TryParse(sparams["StartingIndex"], out var startVal)
+            && startVal > 0
+        )
         {
             start = startVal;
         }
@@ -321,7 +351,7 @@ public class ControlHandler : BaseControlHandler
             Encoding = Encoding.UTF8,
             CloseOutput = false,
             OmitXmlDeclaration = true,
-            ConformanceLevel = ConformanceLevel.Fragment
+            ConformanceLevel = ConformanceLevel.Fragment,
         };
 
         using (StringWriter builder = new StringWriterWithEncoding(Encoding.UTF8))
@@ -345,19 +375,40 @@ public class ControlHandler : BaseControlHandler
                 if (item.IsDisplayedAsFolder || serverItem.StubType.HasValue)
                 {
                     var childrenResult = GetUserItems(
-    item,
-    serverItem.StubType,
-    serverItem.IdSuffix,
-    _user,
-    sortCriteria,
-    start,
-    requestedCount);
+                        item,
+                        serverItem.StubType,
+                        serverItem.IdSuffix,
+                        _user,
+                        sortCriteria,
+                        start,
+                        requestedCount
+                    );
 
-                    _didlBuilder.WriteFolderElement(writer, item, serverItem.StubType, GetAlphabetParentStub(serverItem.StubType) is null ? null : item, childrenResult.TotalRecordCount, filter, id, serverItem.VirtualFolderName, serverItem.IdSuffix, GetAlphabetParentStub(serverItem.StubType));
+                    var alphabetParentStub = GetAlphabetParentStub(serverItem.StubType);
+                    _didlBuilder.WriteFolderElement(
+                        writer,
+                        item,
+                        serverItem.StubType,
+                        alphabetParentStub is null ? null : item,
+                        childrenResult.TotalRecordCount,
+                        filter,
+                        id,
+                        serverItem.VirtualFolderName,
+                        serverItem.IdSuffix,
+                        alphabetParentStub
+                    );
                 }
                 else
                 {
-                    _didlBuilder.WriteItemElement(writer, item, _user, null, null, deviceId, filter);
+                    _didlBuilder.WriteItemElement(
+                        writer,
+                        item,
+                        _user,
+                        null,
+                        null,
+                        deviceId,
+                        filter
+                    );
                 }
 
                 provided++;
@@ -365,13 +416,14 @@ public class ControlHandler : BaseControlHandler
             else
             {
                 var childrenResult = GetUserItems(
-    item,
-    serverItem.StubType,
-    serverItem.IdSuffix,
-    _user,
-    sortCriteria,
-    start,
-    requestedCount);
+                    item,
+                    serverItem.StubType,
+                    serverItem.IdSuffix,
+                    _user,
+                    sortCriteria,
+                    start,
+                    requestedCount
+                );
                 totalCount = childrenResult.TotalRecordCount;
 
                 provided = childrenResult.Items.Count;
@@ -384,20 +436,42 @@ public class ControlHandler : BaseControlHandler
                     if (childItem.IsDisplayedAsFolder || displayStubType.HasValue)
                     {
                         var childCount = GetUserItems(
-    childItem,
-    displayStubType,
-    i.IdSuffix,
-    _user,
-    sortCriteria,
-    null,
-    null)
-                            .TotalRecordCount;
+                            childItem,
+                            displayStubType,
+                            i.IdSuffix,
+                            _user,
+                            sortCriteria,
+                            null,
+                            null
+                        ).TotalRecordCount;
 
-                        _didlBuilder.WriteFolderElement(writer, childItem, displayStubType, item, childCount, filter, null, i.VirtualFolderName, i.IdSuffix, serverItem.StubType, serverItem.IdSuffix);
+                        _didlBuilder.WriteFolderElement(
+                            writer,
+                            childItem,
+                            displayStubType,
+                            item,
+                            childCount,
+                            filter,
+                            null,
+                            i.VirtualFolderName,
+                            i.IdSuffix,
+                            serverItem.StubType,
+                            serverItem.IdSuffix
+                        );
                     }
                     else
                     {
-                        _didlBuilder.WriteItemElement(writer, childItem, _user, item, serverItem.StubType, deviceId, filter, null, serverItem.IdSuffix);
+                        _didlBuilder.WriteItemElement(
+                            writer,
+                            childItem,
+                            _user,
+                            item,
+                            serverItem.StubType,
+                            deviceId,
+                            filter,
+                            null,
+                            serverItem.IdSuffix
+                        );
                     }
                 }
             }
@@ -407,9 +481,18 @@ public class ControlHandler : BaseControlHandler
             xmlWriter.WriteElementString("Result", builder.ToString());
         }
 
-        xmlWriter.WriteElementString("NumberReturned", provided.ToString(CultureInfo.InvariantCulture));
-        xmlWriter.WriteElementString("TotalMatches", totalCount.ToString(CultureInfo.InvariantCulture));
-        xmlWriter.WriteElementString("UpdateID", _systemUpdateId.ToString(CultureInfo.InvariantCulture));
+        xmlWriter.WriteElementString(
+            "NumberReturned",
+            provided.ToString(CultureInfo.InvariantCulture)
+        );
+        xmlWriter.WriteElementString(
+            "TotalMatches",
+            totalCount.ToString(CultureInfo.InvariantCulture)
+        );
+        xmlWriter.WriteElementString(
+            "UpdateID",
+            _systemUpdateId.ToString(CultureInfo.InvariantCulture)
+        );
     }
 
     /// <summary>
@@ -418,7 +501,11 @@ public class ControlHandler : BaseControlHandler
     /// <param name="xmlWriter">The <see cref="XmlWriter"/>.</param>
     /// <param name="sparams">The method parameters.</param>
     /// <param name="deviceId">The device id.</param>
-    private void HandleXBrowseByLetter(XmlWriter xmlWriter, IReadOnlyDictionary<string, string> sparams, string deviceId)
+    private void HandleXBrowseByLetter(
+        XmlWriter xmlWriter,
+        IReadOnlyDictionary<string, string> sparams,
+        string deviceId
+    )
     {
         // TODO: Implement this method
         HandleSearch(xmlWriter, sparams, deviceId);
@@ -430,10 +517,18 @@ public class ControlHandler : BaseControlHandler
     /// <param name="xmlWriter">The xmlWriter<see cref="XmlWriter"/>.</param>
     /// <param name="sparams">The method parameters.</param>
     /// <param name="deviceId">The deviceId<see cref="string"/>.</param>
-    private void HandleSearch(XmlWriter xmlWriter, IReadOnlyDictionary<string, string> sparams, string deviceId)
+    private void HandleSearch(
+        XmlWriter xmlWriter,
+        IReadOnlyDictionary<string, string> sparams,
+        string deviceId
+    )
     {
-        var searchCriteria = new SearchCriteria(sparams.GetValueOrDefault("SearchCriteria", string.Empty));
-        var sortCriteria = new SortCriteria(sparams.GetValueOrDefault("SortCriteria", string.Empty));
+        var searchCriteria = new SearchCriteria(
+            sparams.GetValueOrDefault("SearchCriteria", string.Empty)
+        );
+        var sortCriteria = new SortCriteria(
+            sparams.GetValueOrDefault("SortCriteria", string.Empty)
+        );
         var filter = new Filter(sparams.GetValueOrDefault("Filter", "*"));
 
         // sort example: dc:title, dc:date
@@ -443,12 +538,20 @@ public class ControlHandler : BaseControlHandler
         int? requestedCount = null;
         int? start = 0;
 
-        if (sparams.ContainsKey("RequestedCount") && int.TryParse(sparams["RequestedCount"], out var requestedVal) && requestedVal > 0)
+        if (
+            sparams.ContainsKey("RequestedCount")
+            && int.TryParse(sparams["RequestedCount"], out var requestedVal)
+            && requestedVal > 0
+        )
         {
             requestedCount = requestedVal;
         }
 
-        if (sparams.ContainsKey("StartingIndex") && int.TryParse(sparams["StartingIndex"], out var startVal) && startVal > 0)
+        if (
+            sparams.ContainsKey("StartingIndex")
+            && int.TryParse(sparams["StartingIndex"], out var startVal)
+            && startVal > 0
+        )
         {
             start = startVal;
         }
@@ -459,7 +562,7 @@ public class ControlHandler : BaseControlHandler
             Encoding = Encoding.UTF8,
             CloseOutput = false,
             OmitXmlDeclaration = true,
-            ConformanceLevel = ConformanceLevel.Fragment
+            ConformanceLevel = ConformanceLevel.Fragment,
         };
 
         using (StringWriter builder = new StringWriterWithEncoding(Encoding.UTF8))
@@ -476,19 +579,40 @@ public class ControlHandler : BaseControlHandler
 
             var item = serverItem.Item;
 
-            childrenResult = GetChildrenSorted(item, _user, searchCriteria, sortCriteria, start, requestedCount);
+            childrenResult = GetChildrenSorted(
+                item,
+                _user,
+                searchCriteria,
+                sortCriteria,
+                start,
+                requestedCount
+            );
             foreach (var i in childrenResult.Items)
             {
                 if (i.IsDisplayedAsFolder)
                 {
-                    var childCount = GetChildrenSorted(i, _user, searchCriteria, sortCriteria, null, 0)
-                        .TotalRecordCount;
+                    var childCount = GetChildrenSorted(
+                        i,
+                        _user,
+                        searchCriteria,
+                        sortCriteria,
+                        null,
+                        0
+                    ).TotalRecordCount;
 
                     _didlBuilder.WriteFolderElement(writer, i, null, item, childCount, filter);
                 }
                 else
                 {
-                    _didlBuilder.WriteItemElement(writer, i, _user, item, serverItem.StubType, deviceId, filter);
+                    _didlBuilder.WriteItemElement(
+                        writer,
+                        i,
+                        _user,
+                        item,
+                        serverItem.StubType,
+                        deviceId,
+                        filter
+                    );
                 }
             }
 
@@ -497,9 +621,18 @@ public class ControlHandler : BaseControlHandler
             xmlWriter.WriteElementString("Result", builder.ToString());
         }
 
-        xmlWriter.WriteElementString("NumberReturned", childrenResult.Items.Count.ToString(CultureInfo.InvariantCulture));
-        xmlWriter.WriteElementString("TotalMatches", childrenResult.TotalRecordCount.ToString(CultureInfo.InvariantCulture));
-        xmlWriter.WriteElementString("UpdateID", _systemUpdateId.ToString(CultureInfo.InvariantCulture));
+        xmlWriter.WriteElementString(
+            "NumberReturned",
+            childrenResult.Items.Count.ToString(CultureInfo.InvariantCulture)
+        );
+        xmlWriter.WriteElementString(
+            "TotalMatches",
+            childrenResult.TotalRecordCount.ToString(CultureInfo.InvariantCulture)
+        );
+        xmlWriter.WriteElementString(
+            "UpdateID",
+            _systemUpdateId.ToString(CultureInfo.InvariantCulture)
+        );
     }
 
     /// <summary>
@@ -512,7 +645,14 @@ public class ControlHandler : BaseControlHandler
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The <see cref="QueryResult{BaseItem}"/>.</returns>
-    private static QueryResult<BaseItem> GetChildrenSorted(BaseItem item, User? user, SearchCriteria search, SortCriteria sort, int? startIndex, int? limit)
+    private static QueryResult<BaseItem> GetChildrenSorted(
+        BaseItem item,
+        User? user,
+        SearchCriteria search,
+        SortCriteria sort,
+        int? startIndex,
+        int? limit
+    )
     {
         var folder = (Folder)item;
 
@@ -539,19 +679,21 @@ public class ControlHandler : BaseControlHandler
                 break;
         }
 
-        return folder.GetItems(new InternalItemsQuery
-        {
-            Limit = limit,
-            StartIndex = startIndex,
-            OrderBy = GetOrderBy(sort, folder.IsPreSorted),
-            User = user,
-            Recursive = true,
-            IsMissing = false,
-            ExcludeItemTypes = [BaseItemKind.Book],
-            IsFolder = isFolder,
-            MediaTypes = mediaTypes,
-            DtoOptions = GetDtoOptions()
-        });
+        return folder.GetItems(
+            new InternalItemsQuery
+            {
+                Limit = limit,
+                StartIndex = startIndex,
+                OrderBy = GetOrderBy(sort, folder.IsPreSorted),
+                User = user,
+                Recursive = true,
+                IsMissing = false,
+                ExcludeItemTypes = [BaseItemKind.Book],
+                IsFolder = isFolder,
+                MediaTypes = mediaTypes,
+                DtoOptions = GetDtoOptions(),
+            }
+        );
     }
 
     /// <summary>
@@ -575,13 +717,14 @@ public class ControlHandler : BaseControlHandler
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
     private QueryResult<ServerItem> GetUserItems(
-    BaseItem item,
-    StubType? stubType,
-    string? idSuffix,
-    User? user,
-    SortCriteria sort,
-    int? startIndex,
-    int? limit)
+        BaseItem item,
+        StubType? stubType,
+        string? idSuffix,
+        User? user,
+        SortCriteria sort,
+        int? startIndex,
+        int? limit
+    )
     {
         if (user is not null)
         {
@@ -602,9 +745,25 @@ public class ControlHandler : BaseControlHandler
                     case CollectionType.music:
                         return GetMusicFolders(item, user, stubType, sort, startIndex, limit);
                     case CollectionType.movies:
-                        return GetMovieFolders(item, user, stubType, idSuffix, sort, startIndex, limit);
+                        return GetMovieFolders(
+                            item,
+                            user,
+                            stubType,
+                            idSuffix,
+                            sort,
+                            startIndex,
+                            limit
+                        );
                     case CollectionType.tvshows:
-                        return GetTvFolders(item, user, stubType, idSuffix, sort, startIndex, limit);
+                        return GetTvFolders(
+                            item,
+                            user,
+                            stubType,
+                            idSuffix,
+                            sort,
+                            startIndex,
+                            limit
+                        );
                     case CollectionType.folders:
                         return GetFolders(user, startIndex, limit);
                     case CollectionType.livetv:
@@ -629,7 +788,7 @@ public class ControlHandler : BaseControlHandler
             ExcludeItemTypes = [BaseItemKind.Book],
             IsPlaceHolder = false,
             DtoOptions = GetDtoOptions(),
-            OrderBy = GetOrderBy(sort, folder.IsPreSorted)
+            OrderBy = GetOrderBy(sort, folder.IsPreSorted),
         };
 
         var queryResult = folder.GetItems(query);
@@ -645,14 +804,19 @@ public class ControlHandler : BaseControlHandler
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetLiveTvChannels(User user, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetLiveTvChannels(
+        User user,
+        SortCriteria sort,
+        int? startIndex,
+        int? limit
+    )
     {
         var query = new InternalItemsQuery(user)
         {
             StartIndex = startIndex,
             Limit = limit,
             IncludeItemTypes = [BaseItemKind.LiveTvChannel],
-            OrderBy = GetOrderBy(sort, false)
+            OrderBy = GetOrderBy(sort, false),
         };
 
         var result = _libraryManager.GetItemsResult(query);
@@ -670,13 +834,20 @@ public class ControlHandler : BaseControlHandler
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetMusicFolders(BaseItem item, User user, StubType? stubType, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetMusicFolders(
+        BaseItem item,
+        User user,
+        StubType? stubType,
+        SortCriteria sort,
+        int? startIndex,
+        int? limit
+    )
     {
         var query = new InternalItemsQuery(user)
         {
             StartIndex = startIndex,
             Limit = limit,
-            OrderBy = GetOrderBy(sort, false)
+            OrderBy = GetOrderBy(sort, false),
         };
 
         switch (stubType)
@@ -714,14 +885,11 @@ public class ControlHandler : BaseControlHandler
             new(item, StubType.Genres),
             new(item, StubType.FavoriteArtists),
             new(item, StubType.FavoriteAlbums),
-            new(item, StubType.FavoriteSongs)
+            new(item, StubType.FavoriteSongs),
         };
 
         serverItems = GetTrimmedServerItemsArray(serverItems, startIndex, limit);
-        return new QueryResult<ServerItem>(
-            startIndex,
-            serverItems.Length,
-            serverItems);
+        return new QueryResult<ServerItem>(startIndex, serverItems.Length, serverItems);
     }
 
     /// <summary>
@@ -742,13 +910,14 @@ public class ControlHandler : BaseControlHandler
         string? idSuffix,
         SortCriteria sort,
         int? startIndex,
-        int? limit)
+        int? limit
+    )
     {
         var query = new InternalItemsQuery(user)
         {
             StartIndex = startIndex,
             Limit = limit,
-            OrderBy = GetOrderBy(sort, false)
+            OrderBy = GetOrderBy(sort, false),
         };
 
         switch (stubType)
@@ -776,14 +945,11 @@ public class ControlHandler : BaseControlHandler
             new(item, StubType.Movies),
             new(item, StubType.Collections),
             new(item, StubType.Favorites),
-            new(item, StubType.Genres)
+            new(item, StubType.Genres),
         };
 
         array = GetTrimmedServerItemsArray(array, startIndex, limit);
-        return new QueryResult<ServerItem>(
-            startIndex,
-            array.Length,
-            array);
+        return new QueryResult<ServerItem>(startIndex, array.Length, array);
     }
 
     /// <summary>
@@ -805,10 +971,7 @@ public class ControlHandler : BaseControlHandler
             .Select(i => new ServerItem(i, StubType.Folder))
             .ToArray();
 
-        return new QueryResult<ServerItem>(
-            startIndex,
-            totalRecordCount,
-            items);
+        return new QueryResult<ServerItem>(startIndex, totalRecordCount, items);
     }
 
     /// <summary>
@@ -829,13 +992,14 @@ public class ControlHandler : BaseControlHandler
         string? idSuffix,
         SortCriteria sort,
         int? startIndex,
-        int? limit)
+        int? limit
+    )
     {
         var query = new InternalItemsQuery(user)
         {
             StartIndex = startIndex,
             Limit = limit,
-            OrderBy = GetOrderBy(sort, false)
+            OrderBy = GetOrderBy(sort, false),
         };
 
         switch (stubType)
@@ -866,14 +1030,11 @@ public class ControlHandler : BaseControlHandler
             new(item, StubType.Series),
             new(item, StubType.FavoriteSeries),
             new(item, StubType.FavoriteEpisodes),
-            new(item, StubType.Genres)
+            new(item, StubType.Genres),
         };
 
         serverItems = GetTrimmedServerItemsArray(serverItems, startIndex, limit);
-        return new QueryResult<ServerItem>(
-            startIndex,
-            serverItems.Length,
-            serverItems);
+        return new QueryResult<ServerItem>(startIndex, serverItems.Length, serverItems);
     }
 
     /// <summary>
@@ -882,7 +1043,10 @@ public class ControlHandler : BaseControlHandler
     /// <param name="parent">The <see cref="BaseItem"/>.</param>
     /// <param name="query">The <see cref="InternalItemsQuery"/>.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetMovieContinueWatching(BaseItem parent, InternalItemsQuery query)
+    private QueryResult<ServerItem> GetMovieContinueWatching(
+        BaseItem parent,
+        InternalItemsQuery query
+    )
     {
         query.Recursive = true;
         query.Parent = parent;
@@ -890,7 +1054,7 @@ public class ControlHandler : BaseControlHandler
         query.OrderBy =
         [
             (ItemSortBy.DatePlayed, SortOrder.Descending),
-            (ItemSortBy.SortName, SortOrder.Ascending)
+            (ItemSortBy.SortName, SortOrder.Ascending),
         ];
 
         query.IsResumable = true;
@@ -924,18 +1088,34 @@ public class ControlHandler : BaseControlHandler
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The alphabetical virtual folders.</returns>
-    private static QueryResult<ServerItem> GetAlphabetFolders(BaseItem parent, StubType stubType, int? startIndex, int? limit)
+    private static QueryResult<ServerItem> GetAlphabetFolders(
+        BaseItem parent,
+        StubType stubType,
+        int? startIndex,
+        int? limit
+    )
     {
         var buckets = new[] { "#" }
             .Concat(Enumerable.Range('A', 26).Select(value => ((char)value).ToString()))
-            .Select(bucket => new ServerItem(parent, stubType, bucket, EncodeAlphabetBucket(bucket)))
+            .Append("Other")
+            .Select(bucket => new ServerItem(
+                parent,
+                stubType,
+                bucket,
+                EncodeAlphabetBucket(bucket)
+            ))
             .ToArray();
 
         var items = GetTrimmedServerItemsArray(buckets, startIndex, limit);
         return new QueryResult<ServerItem>(startIndex, buckets.Length, items);
     }
 
-    private QueryResult<ServerItem> GetChildrenByLetter(BaseItem parent, InternalItemsQuery query, BaseItemKind itemType, string? encodedBucket)
+    private QueryResult<ServerItem> GetChildrenByLetter(
+        BaseItem parent,
+        InternalItemsQuery query,
+        BaseItemKind itemType,
+        string? encodedBucket
+    )
     {
         var bucket = DecodeAlphabetBucket(encodedBucket);
         if (bucket is null)
@@ -945,34 +1125,74 @@ public class ControlHandler : BaseControlHandler
 
         if (bucket == "#")
         {
-            query.NameLessThan = "A";
+            query.NameLessThan = "a";
+        }
+        else if (bucket == "Other")
+        {
+            query.NameStartsWithOrGreater = "{";
         }
         else
         {
-            query.NameStartsWithOrGreater = bucket;
-            query.NameLessThan = bucket == "Z" ? "[" : ((char)(bucket[0] + 1)).ToString();
+            var lowerBucket = bucket.ToLowerInvariant();
+            query.NameStartsWithOrGreater = lowerBucket;
+            query.NameLessThan = ((char)(lowerBucket[0] + 1)).ToString();
         }
 
         return GetChildrenOfItem(parent, query, itemType);
     }
 
-    private static string EncodeAlphabetBucket(string bucket) => bucket == "#" ? "0-9" : bucket;
+    private static string EncodeAlphabetBucket(string bucket)
+    {
+        if (bucket == "#")
+        {
+            return "0-9";
+        }
+
+        return string.Equals(bucket, "Other", StringComparison.OrdinalIgnoreCase)
+            ? "other"
+            : bucket;
+    }
 
     private static string? DecodeAlphabetBucket(string? encodedBucket)
-        => string.Equals(encodedBucket, "0-9", StringComparison.OrdinalIgnoreCase) ? "#" : encodedBucket?.ToUpperInvariant();
+    {
+        if (string.IsNullOrWhiteSpace(encodedBucket))
+        {
+            return null;
+        }
 
-    private static string? GetVirtualFolderName(StubType? stubType, string? idSuffix)
-        => stubType is StubType.MovieLetter or StubType.SeriesLetter ? DecodeAlphabetBucket(idSuffix) : null;
+        if (string.Equals(encodedBucket, "0-9", StringComparison.OrdinalIgnoreCase))
+        {
+            return "#";
+        }
 
-    private static StubType? GetAlphabetParentStub(StubType? stubType)
-        => stubType switch
+        if (string.Equals(encodedBucket, "other", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Other";
+        }
+
+        var bucket = encodedBucket.ToUpperInvariant();
+        return bucket.Length == 1 && bucket[0] is >= 'A' and <= 'Z' ? bucket : null;
+    }
+
+    private static string? GetVirtualFolderName(StubType? stubType, string? idSuffix) =>
+        stubType is StubType.MovieLetter or StubType.SeriesLetter
+            ? DecodeAlphabetBucket(idSuffix)
+            : null;
+
+    private static StubType? GetAlphabetParentStub(StubType? stubType) =>
+        stubType switch
         {
             StubType.MovieLetter => StubType.Movies,
             StubType.SeriesLetter => StubType.Series,
-            _ => null
+            _ => null,
         };
 
-    private QueryResult<ServerItem> GetChildrenOfItem(BaseItem parent, InternalItemsQuery query, BaseItemKind itemType, bool isFavorite = false)
+    private QueryResult<ServerItem> GetChildrenOfItem(
+        BaseItem parent,
+        InternalItemsQuery query,
+        BaseItemKind itemType,
+        bool isFavorite = false
+    )
     {
         query.Recursive = true;
         query.Parent = parent;
@@ -1096,10 +1316,11 @@ public class ControlHandler : BaseControlHandler
                 Limit = query.Limit,
                 StartIndex = query.StartIndex,
                 // User cannot be null here as the caller has set it
-                User = query.User!
+                User = query.User!,
             },
             [parent],
-            query.DtoOptions);
+            query.DtoOptions
+        );
 
         return ToResult(query.StartIndex, result);
     }
@@ -1111,7 +1332,11 @@ public class ControlHandler : BaseControlHandler
     /// <param name="query">The <see cref="InternalItemsQuery"/>.</param>
     /// <param name="itemType">The item type.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetLatest(BaseItem parent, InternalItemsQuery query, BaseItemKind itemType)
+    private QueryResult<ServerItem> GetLatest(
+        BaseItem parent,
+        InternalItemsQuery query,
+        BaseItemKind itemType
+    )
     {
         query.OrderBy = [];
 
@@ -1119,24 +1344,30 @@ public class ControlHandler : BaseControlHandler
 
         if (query.StartIndex > 0)
         {
-            limit = (query.Limit <= 0) ? int.MaxValue : (query.StartIndex.Value + (query.Limit ?? 50));
+            limit =
+                (query.Limit <= 0) ? int.MaxValue : (query.StartIndex.Value + (query.Limit ?? 50));
         }
         else
         {
             limit = query.Limit ?? 50;
         }
 
-        var items = _userViewManager.GetLatestItems(
-            new LatestItemsQuery
-            {
-                // User cannot be null here as the caller has set it
-                User = query.User!,
-                Limit = limit,
-                IncludeItemTypes = [itemType],
-                ParentId = parent?.Id ?? Guid.Empty,
-                GroupItems = true
-            },
-            query.DtoOptions).Select(i => i.Item1 ?? i.Item2.FirstOrDefault()).OfType<BaseItem>().ToArray();
+        var items = _userViewManager
+            .GetLatestItems(
+                new LatestItemsQuery
+                {
+                    // User cannot be null here as the caller has set it
+                    User = query.User!,
+                    Limit = limit,
+                    IncludeItemTypes = [itemType],
+                    ParentId = parent?.Id ?? Guid.Empty,
+                    GroupItems = true,
+                },
+                query.DtoOptions
+            )
+            .Select(i => i.Item1 ?? i.Item2.FirstOrDefault())
+            .OfType<BaseItem>()
+            .ToArray();
 
         if (query.StartIndex > 0)
         {
@@ -1155,7 +1386,13 @@ public class ControlHandler : BaseControlHandler
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetMusicArtistItems(BaseItem item, User user, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetMusicArtistItems(
+        BaseItem item,
+        User user,
+        SortCriteria sort,
+        int? startIndex,
+        int? limit
+    )
     {
         var query = new InternalItemsQuery(user)
         {
@@ -1165,7 +1402,7 @@ public class ControlHandler : BaseControlHandler
             Limit = limit,
             StartIndex = startIndex,
             DtoOptions = GetDtoOptions(),
-            OrderBy = GetOrderBy(sort, false)
+            OrderBy = GetOrderBy(sort, false),
         };
 
         var result = _libraryManager.GetItemsResult(query);
@@ -1182,21 +1419,23 @@ public class ControlHandler : BaseControlHandler
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetGenreItems(BaseItem item, User user, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetGenreItems(
+        BaseItem item,
+        User user,
+        SortCriteria sort,
+        int? startIndex,
+        int? limit
+    )
     {
         var query = new InternalItemsQuery(user)
         {
             Recursive = true,
             GenreIds = [item.Id],
-            IncludeItemTypes =
-            [
-                BaseItemKind.Movie,
-                BaseItemKind.Series
-            ],
+            IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Series],
             Limit = limit,
             StartIndex = startIndex,
             DtoOptions = GetDtoOptions(),
-            OrderBy = GetOrderBy(sort, false)
+            OrderBy = GetOrderBy(sort, false),
         };
 
         var result = _libraryManager.GetItemsResult(query);
@@ -1213,7 +1452,13 @@ public class ControlHandler : BaseControlHandler
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetMusicGenreItems(BaseItem item, User user, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetMusicGenreItems(
+        BaseItem item,
+        User user,
+        SortCriteria sort,
+        int? startIndex,
+        int? limit
+    )
     {
         var query = new InternalItemsQuery(user)
         {
@@ -1223,7 +1468,7 @@ public class ControlHandler : BaseControlHandler
             Limit = limit,
             StartIndex = startIndex,
             DtoOptions = GetDtoOptions(),
-            OrderBy = GetOrderBy(sort, false)
+            OrderBy = GetOrderBy(sort, false),
         };
 
         var result = _libraryManager.GetItemsResult(query);
@@ -1239,14 +1484,9 @@ public class ControlHandler : BaseControlHandler
     /// <returns>A <see cref="QueryResult{ServerItem}"/>.</returns>
     private static QueryResult<ServerItem> ToResult(int? startIndex, BaseItem[]? result)
     {
-        var serverItems = result?
-            .Select(i => new ServerItem(i, null))
-            .ToArray();
+        var serverItems = result?.Select(i => new ServerItem(i, null)).ToArray();
 
-        return new QueryResult<ServerItem>(
-            startIndex,
-            result?.Length ?? 0,
-            serverItems ?? []);
+        return new QueryResult<ServerItem>(startIndex, result?.Length ?? 0, serverItems ?? []);
     }
 
     /// <summary>
@@ -1264,10 +1504,7 @@ public class ControlHandler : BaseControlHandler
             serverItems[i] = new ServerItem(result.Items[i], null);
         }
 
-        return new QueryResult<ServerItem>(
-            startIndex,
-            result.TotalRecordCount,
-            serverItems);
+        return new QueryResult<ServerItem>(startIndex, result.TotalRecordCount, serverItems);
     }
 
     /// <summary>
@@ -1276,7 +1513,10 @@ public class ControlHandler : BaseControlHandler
     /// <param name="startIndex">The start index.</param>
     /// <param name="result">A <see cref="QueryResult{BaseItem}"/>.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private static QueryResult<ServerItem> ToResult(int? startIndex, QueryResult<(BaseItem Item, ItemCounts ItemCounts)> result)
+    private static QueryResult<ServerItem> ToResult(
+        int? startIndex,
+        QueryResult<(BaseItem Item, ItemCounts ItemCounts)> result
+    )
     {
         var length = result.Items.Count;
         var serverItems = new ServerItem[length];
@@ -1285,10 +1525,7 @@ public class ControlHandler : BaseControlHandler
             serverItems[i] = new ServerItem(result.Items[i].Item, null);
         }
 
-        return new QueryResult<ServerItem>(
-            startIndex,
-            result.TotalRecordCount,
-            serverItems);
+        return new QueryResult<ServerItem>(startIndex, result.TotalRecordCount, serverItems);
     }
 
     /// <summary>
@@ -1296,9 +1533,14 @@ public class ControlHandler : BaseControlHandler
     /// </summary>
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
     /// <param name="isPreSorted">True if pre-sorted.</param>
-    private static (ItemSortBy SortName, SortOrder SortOrder)[] GetOrderBy(SortCriteria sort, bool isPreSorted)
+    private static (ItemSortBy SortName, SortOrder SortOrder)[] GetOrderBy(
+        SortCriteria sort,
+        bool isPreSorted
+    )
     {
-        return isPreSorted ? Array.Empty<(ItemSortBy, SortOrder)>() : [(ItemSortBy.SortName, sort.SortOrder)];
+        return isPreSorted
+            ? Array.Empty<(ItemSortBy, SortOrder)>()
+            : [(ItemSortBy.SortName, sort.SortOrder)];
     }
 
     /// <summary>
@@ -1358,7 +1600,12 @@ public class ControlHandler : BaseControlHandler
             var item = _libraryManager.GetItemById(itemId);
             if (item is not null)
             {
-                return new ServerItem(item, stubType, GetVirtualFolderName(stubType, idSuffix), idSuffix);
+                return new ServerItem(
+                    item,
+                    stubType,
+                    GetVirtualFolderName(stubType, idSuffix),
+                    idSuffix
+                );
             }
         }
 
@@ -1374,7 +1621,11 @@ public class ControlHandler : BaseControlHandler
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The corresponding trimmed array of <see cref="ServerItem"/></returns>
-    private static ServerItem[] GetTrimmedServerItemsArray(ServerItem[] serverItems, int? startIndex, int? limit)
+    private static ServerItem[] GetTrimmedServerItemsArray(
+        ServerItem[] serverItems,
+        int? startIndex,
+        int? limit
+    )
     {
         if (startIndex >= serverItems.Length)
         {

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -344,9 +344,16 @@ public class ControlHandler : BaseControlHandler
 
                 if (item.IsDisplayedAsFolder || serverItem.StubType.HasValue)
                 {
-                    var childrenResult = GetUserItems(item, serverItem.StubType, _user, sortCriteria, start, requestedCount);
+                    var childrenResult = GetUserItems(
+    item,
+    serverItem.StubType,
+    serverItem.IdSuffix,
+    _user,
+    sortCriteria,
+    start,
+    requestedCount);
 
-                    _didlBuilder.WriteFolderElement(writer, item, serverItem.StubType, null, childrenResult.TotalRecordCount, filter, id);
+                    _didlBuilder.WriteFolderElement(writer, item, serverItem.StubType, GetAlphabetParentStub(serverItem.StubType) is null ? null : item, childrenResult.TotalRecordCount, filter, id, serverItem.VirtualFolderName, serverItem.IdSuffix, GetAlphabetParentStub(serverItem.StubType));
                 }
                 else
                 {
@@ -357,7 +364,14 @@ public class ControlHandler : BaseControlHandler
             }
             else
             {
-                var childrenResult = GetUserItems(item, serverItem.StubType, _user, sortCriteria, start, requestedCount);
+                var childrenResult = GetUserItems(
+    item,
+    serverItem.StubType,
+    serverItem.IdSuffix,
+    _user,
+    sortCriteria,
+    start,
+    requestedCount);
                 totalCount = childrenResult.TotalRecordCount;
 
                 provided = childrenResult.Items.Count;
@@ -369,14 +383,21 @@ public class ControlHandler : BaseControlHandler
 
                     if (childItem.IsDisplayedAsFolder || displayStubType.HasValue)
                     {
-                        var childCount = GetUserItems(childItem, displayStubType, _user, sortCriteria, null, null)
+                        var childCount = GetUserItems(
+    childItem,
+    displayStubType,
+    i.IdSuffix,
+    _user,
+    sortCriteria,
+    null,
+    null)
                             .TotalRecordCount;
 
-                        _didlBuilder.WriteFolderElement(writer, childItem, displayStubType, item, childCount, filter);
+                        _didlBuilder.WriteFolderElement(writer, childItem, displayStubType, item, childCount, filter, null, i.VirtualFolderName, i.IdSuffix, serverItem.StubType, serverItem.IdSuffix);
                     }
                     else
                     {
-                        _didlBuilder.WriteItemElement(writer, childItem, _user, item, serverItem.StubType, deviceId, filter);
+                        _didlBuilder.WriteItemElement(writer, childItem, _user, item, serverItem.StubType, deviceId, filter, null, serverItem.IdSuffix);
                     }
                 }
             }
@@ -547,12 +568,20 @@ public class ControlHandler : BaseControlHandler
     /// </summary>
     /// <param name="item">The <see cref="BaseItem"/>.</param>
     /// <param name="stubType">The <see cref="StubType"/>.</param>
+    /// <param name="idSuffix">The virtual folder ID suffix.</param>
     /// <param name="user">The <see cref="User"/>.</param>
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetUserItems(BaseItem item, StubType? stubType, User? user, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetUserItems(
+    BaseItem item,
+    StubType? stubType,
+    string? idSuffix,
+    User? user,
+    SortCriteria sort,
+    int? startIndex,
+    int? limit)
     {
         if (user is not null)
         {
@@ -573,9 +602,9 @@ public class ControlHandler : BaseControlHandler
                     case CollectionType.music:
                         return GetMusicFolders(item, user, stubType, sort, startIndex, limit);
                     case CollectionType.movies:
-                        return GetMovieFolders(item, user, stubType, sort, startIndex, limit);
+                        return GetMovieFolders(item, user, stubType, idSuffix, sort, startIndex, limit);
                     case CollectionType.tvshows:
-                        return GetTvFolders(item, user, stubType, sort, startIndex, limit);
+                        return GetTvFolders(item, user, stubType, idSuffix, sort, startIndex, limit);
                     case CollectionType.folders:
                         return GetFolders(user, startIndex, limit);
                     case CollectionType.livetv:
@@ -701,11 +730,19 @@ public class ControlHandler : BaseControlHandler
     /// <param name="item">The <see cref="BaseItem"/>.</param>
     /// <param name="user">The <see cref="User"/>.</param>
     /// <param name="stubType">The <see cref="StubType"/>.</param>
+    /// <param name="idSuffix">The alphabetical bucket encoded in the object ID.</param>
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetMovieFolders(BaseItem item, User user, StubType? stubType, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetMovieFolders(
+        BaseItem item,
+        User user,
+        StubType? stubType,
+        string? idSuffix,
+        SortCriteria sort,
+        int? startIndex,
+        int? limit)
     {
         var query = new InternalItemsQuery(user)
         {
@@ -721,7 +758,9 @@ public class ControlHandler : BaseControlHandler
             case StubType.Latest:
                 return GetLatest(item, query, BaseItemKind.Movie);
             case StubType.Movies:
-                return GetChildrenOfItem(item, query, BaseItemKind.Movie);
+                return GetAlphabetFolders(item, StubType.MovieLetter, startIndex, limit);
+            case StubType.MovieLetter:
+                return GetChildrenByLetter(item, query, BaseItemKind.Movie, idSuffix);
             case StubType.Collections:
                 return GetMovieCollections(query);
             case StubType.Favorites:
@@ -778,11 +817,19 @@ public class ControlHandler : BaseControlHandler
     /// <param name="item">The <see cref="BaseItem"/>.</param>
     /// <param name="user">The <see cref="User"/>.</param>
     /// <param name="stubType">The <see cref="StubType"/>.</param>
+    /// <param name="idSuffix">The alphabetical bucket encoded in the object ID.</param>
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetTvFolders(BaseItem item, User user, StubType? stubType, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetTvFolders(
+        BaseItem item,
+        User user,
+        StubType? stubType,
+        string? idSuffix,
+        SortCriteria sort,
+        int? startIndex,
+        int? limit)
     {
         var query = new InternalItemsQuery(user)
         {
@@ -800,7 +847,9 @@ public class ControlHandler : BaseControlHandler
             case StubType.Latest:
                 return GetLatest(item, query, BaseItemKind.Episode);
             case StubType.Series:
-                return GetChildrenOfItem(item, query, BaseItemKind.Series);
+                return GetAlphabetFolders(item, StubType.SeriesLetter, startIndex, limit);
+            case StubType.SeriesLetter:
+                return GetChildrenByLetter(item, query, BaseItemKind.Series, idSuffix);
             case StubType.FavoriteSeries:
                 return GetChildrenOfItem(item, query, BaseItemKind.Series, true);
             case StubType.FavoriteEpisodes:
@@ -868,13 +917,61 @@ public class ControlHandler : BaseControlHandler
     }
 
     /// <summary>
-    /// Returns the children that meet the criteria.
+    /// Returns the alphabetical virtual folders.
     /// </summary>
-    /// <param name="parent">The <see cref="BaseItem"/>.</param>
-    /// <param name="query">The <see cref="InternalItemsQuery"/>.</param>
-    /// <param name="itemType">The item type.</param>
-    /// <param name="isFavorite">A value indicating whether to only fetch favorite items.</param>
-    /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
+    /// <param name="parent">The parent library item.</param>
+    /// <param name="stubType">The virtual folder type.</param>
+    /// <param name="startIndex">The start index.</param>
+    /// <param name="limit">The maximum number to return.</param>
+    /// <returns>The alphabetical virtual folders.</returns>
+    private static QueryResult<ServerItem> GetAlphabetFolders(BaseItem parent, StubType stubType, int? startIndex, int? limit)
+    {
+        var buckets = new[] { "#" }
+            .Concat(Enumerable.Range('A', 26).Select(value => ((char)value).ToString()))
+            .Select(bucket => new ServerItem(parent, stubType, bucket, EncodeAlphabetBucket(bucket)))
+            .ToArray();
+
+        var items = GetTrimmedServerItemsArray(buckets, startIndex, limit);
+        return new QueryResult<ServerItem>(startIndex, buckets.Length, items);
+    }
+
+    private QueryResult<ServerItem> GetChildrenByLetter(BaseItem parent, InternalItemsQuery query, BaseItemKind itemType, string? encodedBucket)
+    {
+        var bucket = DecodeAlphabetBucket(encodedBucket);
+        if (bucket is null)
+        {
+            return new QueryResult<ServerItem>(query.StartIndex, 0, Array.Empty<ServerItem>());
+        }
+
+        if (bucket == "#")
+        {
+            query.NameLessThan = "A";
+        }
+        else
+        {
+            query.NameStartsWithOrGreater = bucket;
+            query.NameLessThan = bucket == "Z" ? "[" : ((char)(bucket[0] + 1)).ToString();
+        }
+
+        return GetChildrenOfItem(parent, query, itemType);
+    }
+
+    private static string EncodeAlphabetBucket(string bucket) => bucket == "#" ? "0-9" : bucket;
+
+    private static string? DecodeAlphabetBucket(string? encodedBucket)
+        => string.Equals(encodedBucket, "0-9", StringComparison.OrdinalIgnoreCase) ? "#" : encodedBucket?.ToUpperInvariant();
+
+    private static string? GetVirtualFolderName(StubType? stubType, string? idSuffix)
+        => stubType is StubType.MovieLetter or StubType.SeriesLetter ? DecodeAlphabetBucket(idSuffix) : null;
+
+    private static StubType? GetAlphabetParentStub(StubType? stubType)
+        => stubType switch
+        {
+            StubType.MovieLetter => StubType.Movies,
+            StubType.SeriesLetter => StubType.Series,
+            _ => null
+        };
+
     private QueryResult<ServerItem> GetChildrenOfItem(BaseItem parent, InternalItemsQuery query, BaseItemKind itemType, bool isFavorite = false)
     {
         query.Recursive = true;
@@ -1224,6 +1321,7 @@ public class ControlHandler : BaseControlHandler
     private ServerItem ParseItemId(string id)
     {
         StubType? stubType = null;
+        string? idSuffix = null;
 
         // After using PlayTo, MediaMonkey sends a request to the server trying to get item info
         const string ParamsSrch = "Params=";
@@ -1237,10 +1335,22 @@ public class ControlHandler : BaseControlHandler
         }
 
         var dividerIndex = id.IndexOf('_', StringComparison.Ordinal);
-        if (dividerIndex != -1 && Enum.TryParse<StubType>(id.AsSpan(0, dividerIndex), true, out var parsedStubType))
+        if (dividerIndex != -1)
         {
-            id = id[(dividerIndex + 1)..];
-            stubType = parsedStubType;
+            var virtualId = id.AsSpan(0, dividerIndex);
+            var suffixIndex = virtualId.IndexOf('-');
+            var stubName = suffixIndex == -1 ? virtualId : virtualId[..suffixIndex];
+
+            if (Enum.TryParse<StubType>(stubName, true, out var parsedStubType))
+            {
+                if (suffixIndex != -1)
+                {
+                    idSuffix = virtualId[(suffixIndex + 1)..].ToString();
+                }
+
+                id = id[(dividerIndex + 1)..];
+                stubType = parsedStubType;
+            }
         }
 
         if (Guid.TryParse(id, out var itemId))
@@ -1248,7 +1358,7 @@ public class ControlHandler : BaseControlHandler
             var item = _libraryManager.GetItemById(itemId);
             if (item is not null)
             {
-                return new ServerItem(item, stubType);
+                return new ServerItem(item, stubType, GetVirtualFolderName(stubType, idSuffix), idSuffix);
             }
         }
 

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ServerItem.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ServerItem.cs
@@ -10,11 +10,15 @@ internal sealed class ServerItem
     /// <summary>
     /// Initializes a new instance of the <see cref="ServerItem"/> class.
     /// </summary>
-    /// <param name="item">The <see cref="BaseItem"/>.</param>
-    /// <param name="stubType">The stub type.</param>
-    public ServerItem(BaseItem item, StubType? stubType)
+    /// <param name="item">The underlying item.</param>
+    /// <param name="stubType">The virtual folder type.</param>
+    /// <param name="virtualFolderName">The displayed name of the virtual folder.</param>
+    /// <param name="idSuffix">The optional suffix encoded in the DLNA object ID.</param>
+    public ServerItem(BaseItem item, StubType? stubType, string? virtualFolderName = null, string? idSuffix = null)
     {
         Item = item;
+        VirtualFolderName = virtualFolderName;
+        IdSuffix = idSuffix;
 
         if (stubType.HasValue)
         {
@@ -35,4 +39,14 @@ internal sealed class ServerItem
     /// Gets the DLNA item type.
     /// </summary>
     public StubType? StubType { get; }
+
+    /// <summary>
+    /// Gets the display name for a virtual folder.
+    /// </summary>
+    public string? VirtualFolderName { get; }
+
+    /// <summary>
+    /// Gets the suffix appended to the virtual folder object id.
+    /// </summary>
+    public string? IdSuffix { get; }
 }

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/StubType.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/StubType.cs
@@ -98,5 +98,15 @@ public enum StubType
     /// <summary>
     /// FavoriteEpisodes stub.
     /// </summary>
-    FavoriteEpisodes = 19
+    FavoriteEpisodes = 19,
+
+    /// <summary>
+    /// Alphabetical movie bucket stub.
+    /// </summary>
+    MovieLetter = 20,
+
+    /// <summary>
+    /// Alphabetical series bucket stub.
+    /// </summary>
+    SeriesLetter = 21
 }

--- a/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
@@ -84,7 +84,8 @@ public class DidlBuilder
         IMediaSourceManager mediaSourceManager,
         ILogger logger,
         IMediaEncoder mediaEncoder,
-        ILibraryManager libraryManager)
+        ILibraryManager libraryManager
+    )
     {
         _profile = profile;
         _user = user;
@@ -117,14 +118,21 @@ public class DidlBuilder
     /// <param name="filter">The <see cref="Filter"/>.</param>
     /// <param name="streamInfo">The <see cref="StreamInfo" />.</param>
     /// </summary>
-    public string GetItemDidl(BaseItem item, User? user, BaseItem? context, string deviceId, Filter filter, StreamInfo streamInfo)
+    public string GetItemDidl(
+        BaseItem item,
+        User? user,
+        BaseItem? context,
+        string deviceId,
+        Filter filter,
+        StreamInfo streamInfo
+    )
     {
         var settings = new XmlWriterSettings
         {
             Encoding = Encoding.UTF8,
             CloseOutput = false,
             OmitXmlDeclaration = true,
-            ConformanceLevel = ConformanceLevel.Fragment
+            ConformanceLevel = ConformanceLevel.Fragment,
         };
 
         using (StringWriter builder = new StringWriterWithEncoding(Encoding.UTF8))
@@ -195,7 +203,8 @@ public class DidlBuilder
         string deviceId,
         Filter filter,
         StreamInfo? streamInfo = null,
-        string? contextIdSuffix = null)
+        string? contextIdSuffix = null
+    )
     {
         var clientId = GetClientId(item, null);
 
@@ -206,7 +215,10 @@ public class DidlBuilder
 
         if (context is not null)
         {
-            writer.WriteAttributeString("parentID", GetClientId(context, contextStubType, contextIdSuffix));
+            writer.WriteAttributeString(
+                "parentID",
+                GetClientId(context, contextStubType, contextIdSuffix)
+            );
         }
         else
         {
@@ -241,20 +253,29 @@ public class DidlBuilder
         writer.WriteFullEndElement();
     }
 
-    private void AddVideoResource(XmlWriter writer, BaseItem video, string deviceId, Filter filter, StreamInfo? streamInfo = null)
+    private void AddVideoResource(
+        XmlWriter writer,
+        BaseItem video,
+        string deviceId,
+        Filter filter,
+        StreamInfo? streamInfo = null
+    )
     {
         if (streamInfo is null)
         {
             var sources = _mediaSourceManager.GetStaticMediaSources(video, true, _user);
 
-            streamInfo = new StreamBuilder(_mediaEncoder, _logger).GetOptimalVideoStream(new MediaOptions
-            {
-                ItemId = video.Id,
-                MediaSources = sources.ToArray(),
-                Profile = _profile,
-                DeviceId = deviceId,
-                MaxBitrate = _profile.MaxStreamingBitrate
-            }) ?? throw new InvalidOperationException("No optimal video stream found");
+            streamInfo =
+                new StreamBuilder(_mediaEncoder, _logger).GetOptimalVideoStream(
+                    new MediaOptions
+                    {
+                        ItemId = video.Id,
+                        MediaSources = sources.ToArray(),
+                        Profile = _profile,
+                        DeviceId = deviceId,
+                        MaxBitrate = _profile.MaxStreamingBitrate,
+                    }
+                ) ?? throw new InvalidOperationException("No optimal video stream found");
         }
 
         var targetWidth = streamInfo.TargetWidth;
@@ -287,14 +308,20 @@ public class DidlBuilder
             streamInfo.TargetAudioStreamCount,
             streamInfo.GetStreamCount(),
             streamInfo.TargetVideoCodecTag,
-            streamInfo.IsTargetAVC);
+            streamInfo.IsTargetAVC
+        );
 
         foreach (var contentFeature in contentFeatureList)
         {
             AddVideoResource(writer, filter, contentFeature, streamInfo);
         }
 
-        var subtitleProfiles = streamInfo.GetSubtitleProfiles(_mediaEncoder, false, _serverAddress, _accessToken);
+        var subtitleProfiles = streamInfo.GetSubtitleProfiles(
+            _mediaEncoder,
+            false,
+            _serverAddress,
+            _accessToken
+        );
 
         foreach (var subtitle in subtitleProfiles)
         {
@@ -314,9 +341,10 @@ public class DidlBuilder
 
     private bool AddSubtitleElement(XmlWriter writer, SubtitleStreamInfo info)
     {
-        var subtitleProfile = _profile.SubtitleProfiles
-            .FirstOrDefault(i => string.Equals(info.Format, i.Format, StringComparison.OrdinalIgnoreCase)
-                                 && i.Method == SubtitleDeliveryMethod.External);
+        var subtitleProfile = _profile.SubtitleProfiles.FirstOrDefault(i =>
+            string.Equals(info.Format, i.Format, StringComparison.OrdinalIgnoreCase)
+            && i.Method == SubtitleDeliveryMethod.External
+        );
 
         if (subtitleProfile is null)
         {
@@ -351,7 +379,8 @@ public class DidlBuilder
             var protocolInfo = string.Format(
                 CultureInfo.InvariantCulture,
                 "http-get:*:text/{0}:*",
-                info.Format.ToLowerInvariant());
+                info.Format.ToLowerInvariant()
+            );
             writer.WriteAttributeString("protocolInfo", protocolInfo);
 
             writer.WriteString(info.Url);
@@ -361,7 +390,12 @@ public class DidlBuilder
         return true;
     }
 
-    private void AddVideoResource(XmlWriter writer, Filter filter, string contentFeatures, StreamInfo streamInfo)
+    private void AddVideoResource(
+        XmlWriter writer,
+        Filter filter,
+        string contentFeatures,
+        StreamInfo streamInfo
+    )
     {
         writer.WriteStartElement(string.Empty, "res", NsDidl);
 
@@ -371,7 +405,12 @@ public class DidlBuilder
 
         if (mediaSource?.RunTimeTicks.HasValue == true)
         {
-            writer.WriteAttributeString("duration", TimeSpan.FromTicks(mediaSource.RunTimeTicks.Value).ToString("c", CultureInfo.InvariantCulture));
+            writer.WriteAttributeString(
+                "duration",
+                TimeSpan
+                    .FromTicks(mediaSource.RunTimeTicks.Value)
+                    .ToString("c", CultureInfo.InvariantCulture)
+            );
         }
 
         if (filter.Contains("res@size"))
@@ -382,7 +421,10 @@ public class DidlBuilder
 
                 if (size.HasValue)
                 {
-                    writer.WriteAttributeString("size", size.Value.ToString(CultureInfo.InvariantCulture));
+                    writer.WriteAttributeString(
+                        "size",
+                        size.Value.ToString(CultureInfo.InvariantCulture)
+                    );
                 }
             }
         }
@@ -396,7 +438,10 @@ public class DidlBuilder
 
         if (targetChannels.HasValue)
         {
-            writer.WriteAttributeString("nrAudioChannels", targetChannels.Value.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString(
+                "nrAudioChannels",
+                targetChannels.Value.ToString(CultureInfo.InvariantCulture)
+            );
         }
 
         if (filter.Contains("res@resolution"))
@@ -409,18 +454,26 @@ public class DidlBuilder
                         CultureInfo.InvariantCulture,
                         "{0}x{1}",
                         targetWidth.Value,
-                        targetHeight.Value));
+                        targetHeight.Value
+                    )
+                );
             }
         }
 
         if (targetSampleRate.HasValue)
         {
-            writer.WriteAttributeString("sampleFrequency", targetSampleRate.Value.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString(
+                "sampleFrequency",
+                targetSampleRate.Value.ToString(CultureInfo.InvariantCulture)
+            );
         }
 
         if (totalBitrate.HasValue)
         {
-            writer.WriteAttributeString("bitrate", totalBitrate.Value.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString(
+                "bitrate",
+                totalBitrate.Value.ToString(CultureInfo.InvariantCulture)
+            );
         }
 
         var mediaProfile = _profile.GetVideoMediaProfile(
@@ -444,13 +497,15 @@ public class DidlBuilder
             streamInfo.TargetAudioStreamCount,
             streamInfo.GetStreamCount(),
             streamInfo.TargetVideoCodecTag,
-            streamInfo.IsTargetAVC);
+            streamInfo.IsTargetAVC
+        );
 
         var filename = url[..url.IndexOf('?', StringComparison.Ordinal)];
 
-        var mimeType = mediaProfile is null || string.IsNullOrEmpty(mediaProfile.MimeType)
-            ? MimeTypes.GetMimeType(filename)
-            : mediaProfile.MimeType;
+        var mimeType =
+            mediaProfile is null || string.IsNullOrEmpty(mediaProfile.MimeType)
+                ? MimeTypes.GetMimeType(filename)
+                : mediaProfile.MimeType;
 
         writer.WriteAttributeString(
             "protocolInfo",
@@ -458,14 +513,21 @@ public class DidlBuilder
                 CultureInfo.InvariantCulture,
                 "http-get:*:{0}:{1}",
                 mimeType,
-                contentFeatures));
+                contentFeatures
+            )
+        );
 
         writer.WriteString(url);
 
         writer.WriteFullEndElement();
     }
 
-    private string GetDisplayName(BaseItem item, StubType? itemStubType, BaseItem? context, string? virtualFolderName = null)
+    private string GetDisplayName(
+        BaseItem item,
+        StubType? itemStubType,
+        BaseItem? context,
+        string? virtualFolderName = null
+    )
     {
         if (!string.IsNullOrEmpty(virtualFolderName))
         {
@@ -476,30 +538,49 @@ public class DidlBuilder
         {
             switch (itemStubType.Value)
             {
-                case StubType.Latest: return _localization.GetLocalizedString("Latest");
-                case StubType.Playlists: return _localization.GetLocalizedString("Playlists");
-                case StubType.AlbumArtists: return _localization.GetLocalizedString("HeaderAlbumArtists");
-                case StubType.Albums: return _localization.GetLocalizedString("Albums");
-                case StubType.Artists: return _localization.GetLocalizedString("Artists");
-                case StubType.Songs: return _localization.GetLocalizedString("Songs");
-                case StubType.Genres: return _localization.GetLocalizedString("Genres");
-                case StubType.FavoriteAlbums: return _localization.GetLocalizedString("HeaderFavoriteAlbums");
-                case StubType.FavoriteArtists: return _localization.GetLocalizedString("HeaderFavoriteArtists");
-                case StubType.FavoriteSongs: return _localization.GetLocalizedString("HeaderFavoriteSongs");
-                case StubType.ContinueWatching: return _localization.GetLocalizedString("HeaderContinueWatching");
-                case StubType.Movies: return _localization.GetLocalizedString("Movies");
-                case StubType.Collections: return _localization.GetLocalizedString("Collections");
-                case StubType.Favorites: return _localization.GetLocalizedString("Favorites");
-                case StubType.NextUp: return _localization.GetLocalizedString("HeaderNextUp");
-                case StubType.FavoriteSeries: return _localization.GetLocalizedString("HeaderFavoriteShows");
-                case StubType.FavoriteEpisodes: return _localization.GetLocalizedString("HeaderFavoriteEpisodes");
-                case StubType.Series: return _localization.GetLocalizedString("Shows");
+                case StubType.Latest:
+                    return _localization.GetLocalizedString("Latest");
+                case StubType.Playlists:
+                    return _localization.GetLocalizedString("Playlists");
+                case StubType.AlbumArtists:
+                    return _localization.GetLocalizedString("HeaderAlbumArtists");
+                case StubType.Albums:
+                    return _localization.GetLocalizedString("Albums");
+                case StubType.Artists:
+                    return _localization.GetLocalizedString("Artists");
+                case StubType.Songs:
+                    return _localization.GetLocalizedString("Songs");
+                case StubType.Genres:
+                    return _localization.GetLocalizedString("Genres");
+                case StubType.FavoriteAlbums:
+                    return _localization.GetLocalizedString("HeaderFavoriteAlbums");
+                case StubType.FavoriteArtists:
+                    return _localization.GetLocalizedString("HeaderFavoriteArtists");
+                case StubType.FavoriteSongs:
+                    return _localization.GetLocalizedString("HeaderFavoriteSongs");
+                case StubType.ContinueWatching:
+                    return _localization.GetLocalizedString("HeaderContinueWatching");
+                case StubType.Movies:
+                    return _localization.GetLocalizedString("Movies");
+                case StubType.Collections:
+                    return _localization.GetLocalizedString("Collections");
+                case StubType.Favorites:
+                    return _localization.GetLocalizedString("Favorites");
+                case StubType.NextUp:
+                    return _localization.GetLocalizedString("HeaderNextUp");
+                case StubType.FavoriteSeries:
+                    return _localization.GetLocalizedString("HeaderFavoriteShows");
+                case StubType.FavoriteEpisodes:
+                    return _localization.GetLocalizedString("HeaderFavoriteEpisodes");
+                case StubType.Series:
+                    return _localization.GetLocalizedString("Shows");
+                case StubType.MovieLetter:
+                case StubType.SeriesLetter:
+                    return item.Name;
             }
         }
 
-        return item is Episode episode
-            ? GetEpisodeDisplayName(episode, context)
-            : item.Name;
+        return item is Episode episode ? GetEpisodeDisplayName(episode, context) : item.Name;
     }
 
     /// <summary>
@@ -519,13 +600,18 @@ public class DidlBuilder
         if (context is Season season)
         {
             // This is a special embedded within a season
-            if (episode.ParentIndexNumber.HasValue && episode.ParentIndexNumber.Value == 0
-                                                   && season.IndexNumber.HasValue && season.IndexNumber.Value != 0)
+            if (
+                episode.ParentIndexNumber.HasValue
+                && episode.ParentIndexNumber.Value == 0
+                && season.IndexNumber.HasValue
+                && season.IndexNumber.Value != 0
+            )
             {
                 return string.Format(
                     CultureInfo.InvariantCulture,
                     _localization.GetLocalizedString("ValueSpecialEpisodeName"),
-                    episode.Name);
+                    episode.Name
+                );
             }
 
             // inside a season use simple format (ex. '12 - Episode Name')
@@ -556,7 +642,8 @@ public class DidlBuilder
 
             if (episode.IndexNumberEnd.HasValue)
             {
-                name += "-" + episode.IndexNumberEnd.Value.ToString("00", CultureInfo.InvariantCulture);
+                name +=
+                    "-" + episode.IndexNumberEnd.Value.ToString("00", CultureInfo.InvariantCulture);
             }
         }
 
@@ -585,7 +672,13 @@ public class DidlBuilder
 
     private bool NotNullOrWhiteSpace(string s) => !string.IsNullOrWhiteSpace(s);
 
-    private void AddAudioResource(XmlWriter writer, BaseItem audio, string deviceId, Filter filter, StreamInfo? streamInfo = null)
+    private void AddAudioResource(
+        XmlWriter writer,
+        BaseItem audio,
+        string deviceId,
+        Filter filter,
+        StreamInfo? streamInfo = null
+    )
     {
         writer.WriteStartElement(string.Empty, "res", NsDidl);
 
@@ -593,13 +686,16 @@ public class DidlBuilder
         {
             var sources = _mediaSourceManager.GetStaticMediaSources(audio, true, _user);
 
-            streamInfo = new StreamBuilder(_mediaEncoder, _logger).GetOptimalAudioStream(new MediaOptions
-            {
-                ItemId = audio.Id,
-                MediaSources = sources.ToArray(),
-                Profile = _profile,
-                DeviceId = deviceId
-            }) ?? throw new InvalidOperationException("No optimal audio stream found");
+            streamInfo =
+                new StreamBuilder(_mediaEncoder, _logger).GetOptimalAudioStream(
+                    new MediaOptions
+                    {
+                        ItemId = audio.Id,
+                        MediaSources = sources.ToArray(),
+                        Profile = _profile,
+                        DeviceId = deviceId,
+                    }
+                ) ?? throw new InvalidOperationException("No optimal audio stream found");
         }
 
         var url = NormalizeDlnaMediaUrl(streamInfo.ToDlnaUrl(_serverAddress, _accessToken));
@@ -608,7 +704,12 @@ public class DidlBuilder
 
         if (mediaSource?.RunTimeTicks is not null)
         {
-            writer.WriteAttributeString("duration", TimeSpan.FromTicks(mediaSource.RunTimeTicks.Value).ToString("c", CultureInfo.InvariantCulture));
+            writer.WriteAttributeString(
+                "duration",
+                TimeSpan
+                    .FromTicks(mediaSource.RunTimeTicks.Value)
+                    .ToString("c", CultureInfo.InvariantCulture)
+            );
         }
 
         if (filter.Contains("res@size"))
@@ -619,7 +720,10 @@ public class DidlBuilder
 
                 if (size.HasValue)
                 {
-                    writer.WriteAttributeString("size", size.Value.ToString(CultureInfo.InvariantCulture));
+                    writer.WriteAttributeString(
+                        "size",
+                        size.Value.ToString(CultureInfo.InvariantCulture)
+                    );
                 }
             }
         }
@@ -631,17 +735,26 @@ public class DidlBuilder
 
         if (targetChannels.HasValue)
         {
-            writer.WriteAttributeString("nrAudioChannels", targetChannels.Value.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString(
+                "nrAudioChannels",
+                targetChannels.Value.ToString(CultureInfo.InvariantCulture)
+            );
         }
 
         if (targetSampleRate.HasValue)
         {
-            writer.WriteAttributeString("sampleFrequency", targetSampleRate.Value.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString(
+                "sampleFrequency",
+                targetSampleRate.Value.ToString(CultureInfo.InvariantCulture)
+            );
         }
 
         if (targetAudioBitrate.HasValue)
         {
-            writer.WriteAttributeString("bitrate", targetAudioBitrate.Value.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString(
+                "bitrate",
+                targetAudioBitrate.Value.ToString(CultureInfo.InvariantCulture)
+            );
         }
 
         var mediaProfile = _profile.GetAudioMediaProfile(
@@ -650,13 +763,15 @@ public class DidlBuilder
             targetChannels,
             targetAudioBitrate,
             targetSampleRate,
-            targetAudioBitDepth);
+            targetAudioBitDepth
+        );
 
         var filename = url[..url.IndexOf('?', StringComparison.Ordinal)];
 
-        var mimeType = mediaProfile is null || string.IsNullOrEmpty(mediaProfile.MimeType)
-            ? MimeTypes.GetMimeType(filename)
-            : mediaProfile.MimeType;
+        var mimeType =
+            mediaProfile is null || string.IsNullOrEmpty(mediaProfile.MimeType)
+                ? MimeTypes.GetMimeType(filename)
+                : mediaProfile.MimeType;
 
         var contentFeatures = ContentFeatureBuilder.BuildAudioHeader(
             _profile,
@@ -668,7 +783,8 @@ public class DidlBuilder
             targetAudioBitDepth,
             streamInfo.IsDirectStream,
             streamInfo.RunTimeTicks ?? 0,
-            streamInfo.TranscodeSeekInfo);
+            streamInfo.TranscodeSeekInfo
+        );
 
         writer.WriteAttributeString(
             "protocolInfo",
@@ -676,7 +792,9 @@ public class DidlBuilder
                 CultureInfo.InvariantCulture,
                 "http-get:*:{0}:{1}",
                 mimeType,
-                contentFeatures));
+                contentFeatures
+            )
+        );
 
         writer.WriteString(url);
 
@@ -688,11 +806,11 @@ public class DidlBuilder
     /// </summary>
     /// <param name="id">The id.</param>
     /// <returns><c>true</c> if the id is a root id; otherwise, <c>false</c>.</returns>
-    public static bool IsIdRoot(string id)
-        => string.IsNullOrWhiteSpace(id)
-           || string.Equals(id, "0", StringComparison.OrdinalIgnoreCase)
-           // Samsung sometimes uses 1 as root
-           || string.Equals(id, "1", StringComparison.OrdinalIgnoreCase);
+    public static bool IsIdRoot(string id) =>
+        string.IsNullOrWhiteSpace(id)
+        || string.Equals(id, "0", StringComparison.OrdinalIgnoreCase)
+        // Samsung sometimes uses 1 as root
+        || string.Equals(id, "1", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Writes an XML folder element.
@@ -708,13 +826,28 @@ public class DidlBuilder
     /// <param name="contextStubType">The parent virtual-folder type.</param>
     /// <param name="contextIdSuffix">The parent virtual-folder ID suffix.</param>
     /// </summary>
-    public void WriteFolderElement(XmlWriter writer, BaseItem folder, StubType? stubType, BaseItem? context, int childCount, Filter filter, string? requestedId = null, string? virtualFolderName = null, string? idSuffix = null, StubType? contextStubType = null, string? contextIdSuffix = null)
+    public void WriteFolderElement(
+        XmlWriter writer,
+        BaseItem folder,
+        StubType? stubType,
+        BaseItem? context,
+        int childCount,
+        Filter filter,
+        string? requestedId = null,
+        string? virtualFolderName = null,
+        string? idSuffix = null,
+        StubType? contextStubType = null,
+        string? contextIdSuffix = null
+    )
     {
         writer.WriteStartElement(string.Empty, "container", NsDidl);
 
         writer.WriteAttributeString("restricted", "1");
         writer.WriteAttributeString("searchable", "1");
-        writer.WriteAttributeString("childCount", childCount.ToString(CultureInfo.InvariantCulture));
+        writer.WriteAttributeString(
+            "childCount",
+            childCount.ToString(CultureInfo.InvariantCulture)
+        );
 
         var clientId = GetClientId(folder, stubType, idSuffix);
 
@@ -729,7 +862,10 @@ public class DidlBuilder
 
             if (context is not null)
             {
-                writer.WriteAttributeString("parentID", GetClientId(context, contextStubType, contextIdSuffix));
+                writer.WriteAttributeString(
+                    "parentID",
+                    GetClientId(context, contextStubType, contextIdSuffix)
+                );
             }
             else
             {
@@ -752,7 +888,12 @@ public class DidlBuilder
         writer.WriteFullEndElement();
     }
 
-    private void AddSamsungBookmarkInfo(BaseItem item, User? user, XmlWriter writer, StreamInfo? streamInfo)
+    private void AddSamsungBookmarkInfo(
+        BaseItem item,
+        User? user,
+        XmlWriter writer,
+        StreamInfo? streamInfo
+    )
     {
         if (!item.SupportsPositionTicksResume || item is Folder)
         {
@@ -776,25 +917,42 @@ public class DidlBuilder
         }
 
         var userdata = _userDataManager.GetUserData(user, item)!;
-        var playbackPositionTicks = (streamInfo is not null && streamInfo.StartPositionTicks > 0) ? streamInfo.StartPositionTicks : userdata.PlaybackPositionTicks;
+        var playbackPositionTicks =
+            (streamInfo is not null && streamInfo.StartPositionTicks > 0)
+                ? streamInfo.StartPositionTicks
+                : userdata.PlaybackPositionTicks;
 
         if (playbackPositionTicks > 0)
         {
             var elementValue = string.Format(
                 CultureInfo.InvariantCulture,
                 "BM={0}",
-                Convert.ToInt32(TimeSpan.FromTicks(playbackPositionTicks).TotalSeconds));
+                Convert.ToInt32(TimeSpan.FromTicks(playbackPositionTicks).TotalSeconds)
+            );
             AddValue(writer, "sec", "dcmInfo", elementValue, secAttribute.Value);
         }
     }
 
-    private void AddCommonFields(BaseItem item, StubType? itemStubType, BaseItem? context, XmlWriter writer, Filter filter, string? virtualFolderName = null)
+    private void AddCommonFields(
+        BaseItem item,
+        StubType? itemStubType,
+        BaseItem? context,
+        XmlWriter writer,
+        Filter filter,
+        string? virtualFolderName = null
+    )
     {
         // Don't filter on dc:title because not all devices will include it in the filter
         // MediaMonkey for example won't display content without a title
         // if (filter.Contains("dc:title"))
         {
-            AddValue(writer, "dc", "title", GetDisplayName(item, itemStubType, context, virtualFolderName), NsDc);
+            AddValue(
+                writer,
+                "dc",
+                "title",
+                GetDisplayName(item, itemStubType, context, virtualFolderName),
+                NsDc
+            );
         }
 
         WriteObjectClass(writer, item, itemStubType);
@@ -803,7 +961,13 @@ public class DidlBuilder
         {
             if (item.PremiereDate.HasValue)
             {
-                AddValue(writer, "dc", "date", item.PremiereDate.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), NsDc);
+                AddValue(
+                    writer,
+                    "dc",
+                    "date",
+                    item.PremiereDate.Value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                    NsDc
+                );
             }
         }
 
@@ -919,11 +1083,19 @@ public class DidlBuilder
         }
         else if (item is MusicGenre)
         {
-            writer.WriteString(_profile.RequiresPlainFolders ? "object.container.storageFolder" : "object.container.genre.musicGenre");
+            writer.WriteString(
+                _profile.RequiresPlainFolders
+                    ? "object.container.storageFolder"
+                    : "object.container.genre.musicGenre"
+            );
         }
         else if (item is Genre)
         {
-            writer.WriteString(_profile.RequiresPlainFolders ? "object.container.storageFolder" : "object.container.genre");
+            writer.WriteString(
+                _profile.RequiresPlainFolders
+                    ? "object.container.storageFolder"
+                    : "object.container.genre"
+            );
         }
         else
         {
@@ -946,21 +1118,21 @@ public class DidlBuilder
             PersonKind.Writer,
             PersonKind.Producer,
             PersonKind.Composer,
-            PersonKind.Creator
+            PersonKind.Creator,
         };
 
         // Seeing some LG models locking up due content with large lists of people
         // The actual issue might just be due to processing a more metadata than it can handle
         var people = _libraryManager.GetPeople(
-            new InternalPeopleQuery
-            {
-                ItemId = item.Id,
-                Limit = 6
-            });
+            new InternalPeopleQuery { ItemId = item.Id, Limit = 6 }
+        );
 
         foreach (var actor in people)
         {
-            var type = types.FirstOrDefault(i => i == actor.Type || string.Equals(actor.Role, i.ToString(), StringComparison.OrdinalIgnoreCase));
+            var type = types.FirstOrDefault(i =>
+                i == actor.Type
+                || string.Equals(actor.Role, i.ToString(), StringComparison.OrdinalIgnoreCase)
+            );
             if (type == PersonKind.Unknown)
             {
                 type = PersonKind.Actor;
@@ -970,7 +1142,14 @@ public class DidlBuilder
         }
     }
 
-    private void AddGeneralProperties(BaseItem item, StubType? itemStubType, BaseItem? context, XmlWriter writer, Filter filter, string? virtualFolderName = null)
+    private void AddGeneralProperties(
+        BaseItem item,
+        StubType? itemStubType,
+        BaseItem? context,
+        XmlWriter writer,
+        Filter filter,
+        string? virtualFolderName = null
+    )
     {
         AddCommonFields(item, itemStubType, context, writer, filter, virtualFolderName);
 
@@ -1006,11 +1185,23 @@ public class DidlBuilder
 
         if (item.IndexNumber.HasValue)
         {
-            AddValue(writer, "upnp", "originalTrackNumber", item.IndexNumber.Value.ToString(CultureInfo.InvariantCulture), NsUpnp);
+            AddValue(
+                writer,
+                "upnp",
+                "originalTrackNumber",
+                item.IndexNumber.Value.ToString(CultureInfo.InvariantCulture),
+                NsUpnp
+            );
 
             if (item is Episode)
             {
-                AddValue(writer, "upnp", "episodeNumber", item.IndexNumber.Value.ToString(CultureInfo.InvariantCulture), NsUpnp);
+                AddValue(
+                    writer,
+                    "upnp",
+                    "episodeNumber",
+                    item.IndexNumber.Value.ToString(CultureInfo.InvariantCulture),
+                    NsUpnp
+                );
             }
         }
     }
@@ -1032,7 +1223,13 @@ public class DidlBuilder
         }
     }
 
-    private void AddValue(XmlWriter writer, string prefix, string name, string value, string namespaceUri)
+    private void AddValue(
+        XmlWriter writer,
+        string prefix,
+        string name,
+        string value,
+        string namespaceUri
+    )
     {
         try
         {
@@ -1058,7 +1255,8 @@ public class DidlBuilder
             imageInfo,
             _profile.MaxAlbumArtWidth ?? 10000,
             _profile.MaxAlbumArtHeight ?? 10000,
-            "jpg");
+            "jpg"
+        );
 
         writer.WriteStartElement("upnp", "albumArtURI", NsUpnp);
         if (!string.IsNullOrEmpty(_profile.AlbumArtPn))
@@ -1074,7 +1272,8 @@ public class DidlBuilder
             imageInfo,
             _profile.MaxIconWidth ?? 48,
             _profile.MaxIconHeight ?? 48,
-            "jpg");
+            "jpg"
+        );
         writer.WriteElementString("upnp", "icon", NsUpnp, iconUrlInfo.Url);
 
         if (!_profile.EnableAlbumArtInDidl)
@@ -1106,7 +1305,8 @@ public class DidlBuilder
         int maxWidth,
         int maxHeight,
         string format,
-        string org_Pn)
+        string org_Pn
+    )
     {
         var imageInfo = GetImageInfo(item);
 
@@ -1124,7 +1324,14 @@ public class DidlBuilder
         var width = albumartUrlInfo.Width ?? maxWidth;
         var height = albumartUrlInfo.Height ?? maxHeight;
 
-        var contentFeatures = ContentFeatureBuilder.BuildImageHeader(_profile, format, width, height, imageInfo.IsDirectStream, org_Pn);
+        var contentFeatures = ContentFeatureBuilder.BuildImageHeader(
+            _profile,
+            format,
+            width,
+            height,
+            imageInfo.IsDirectStream,
+            org_Pn
+        );
 
         writer.WriteAttributeString(
             "protocolInfo",
@@ -1132,11 +1339,14 @@ public class DidlBuilder
                 CultureInfo.InvariantCulture,
                 "http-get:*:{0}:{1}",
                 MimeTypes.GetMimeType("file." + format),
-                contentFeatures));
+                contentFeatures
+            )
+        );
 
         writer.WriteAttributeString(
             "resolution",
-            string.Format(CultureInfo.InvariantCulture, "{0}x{1}", width, height));
+            string.Format(CultureInfo.InvariantCulture, "{0}x{1}", width, height)
+        );
 
         writer.WriteString(albumartUrlInfo.Url);
 
@@ -1255,7 +1465,7 @@ public class DidlBuilder
             Width = width,
             Height = height,
             Format = inputFormat,
-            ItemImageInfo = imageInfo
+            ItemImageInfo = imageInfo,
         };
     }
 
@@ -1284,15 +1494,26 @@ public class DidlBuilder
 
         if (stubType.HasValue)
         {
-            id = stubType.Value.ToString().ToLowerInvariant()
-                + (string.IsNullOrEmpty(idSuffix) ? string.Empty : "-" + idSuffix.ToLowerInvariant())
-                + "_" + id;
+            id =
+                stubType.Value.ToString().ToLowerInvariant()
+                + (
+                    string.IsNullOrEmpty(idSuffix)
+                        ? string.Empty
+                        : "-" + idSuffix.ToLowerInvariant()
+                )
+                + "_"
+                + id;
         }
 
         return id;
     }
 
-    private (string Url, int? Width, int? Height) GetImageUrl(ImageDownloadInfo info, int maxWidth, int maxHeight, string format)
+    private (string Url, int? Width, int? Height) GetImageUrl(
+        ImageDownloadInfo info,
+        int maxWidth,
+        int maxHeight,
+        string format
+    )
     {
         var url = string.Format(
             CultureInfo.InvariantCulture,
@@ -1303,7 +1524,8 @@ public class DidlBuilder
             info.ImageTag,
             format,
             maxWidth.ToString(CultureInfo.InvariantCulture),
-            maxHeight.ToString(CultureInfo.InvariantCulture));
+            maxHeight.ToString(CultureInfo.InvariantCulture)
+        );
 
         var width = info.Width;
         var height = info.Height;
@@ -1312,13 +1534,22 @@ public class DidlBuilder
 
         if (width.HasValue && height.HasValue)
         {
-            var newSize = DrawingUtils.Resize(new ImageDimensions(width.Value, height.Value), 0, 0, maxWidth, maxHeight);
+            var newSize = DrawingUtils.Resize(
+                new ImageDimensions(width.Value, height.Value),
+                0,
+                0,
+                maxWidth,
+                maxHeight
+            );
 
             width = newSize.Width;
             height = newSize.Height;
 
-            var normalizedFormat = format
-                .Replace("jpeg", "jpg", StringComparison.OrdinalIgnoreCase);
+            var normalizedFormat = format.Replace(
+                "jpeg",
+                "jpg",
+                StringComparison.OrdinalIgnoreCase
+            );
 
             if (string.Equals(info.Format, normalizedFormat, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
@@ -184,6 +184,7 @@ public class DidlBuilder
     /// <param name="deviceId">The device id.</param>
     /// <param name="filter">The <see cref="Filter"/>.</param>
     /// <param name="streamInfo">The <see cref="StreamInfo" />.</param>
+    /// <param name="contextIdSuffix">The parent virtual-folder ID suffix.</param>
     /// </summary>
     public void WriteItemElement(
         XmlWriter writer,
@@ -193,7 +194,8 @@ public class DidlBuilder
         StubType? contextStubType,
         string deviceId,
         Filter filter,
-        StreamInfo? streamInfo = null)
+        StreamInfo? streamInfo = null,
+        string? contextIdSuffix = null)
     {
         var clientId = GetClientId(item, null);
 
@@ -204,7 +206,7 @@ public class DidlBuilder
 
         if (context is not null)
         {
-            writer.WriteAttributeString("parentID", GetClientId(context, contextStubType));
+            writer.WriteAttributeString("parentID", GetClientId(context, contextStubType, contextIdSuffix));
         }
         else
         {
@@ -463,8 +465,13 @@ public class DidlBuilder
         writer.WriteFullEndElement();
     }
 
-    private string GetDisplayName(BaseItem item, StubType? itemStubType, BaseItem? context)
+    private string GetDisplayName(BaseItem item, StubType? itemStubType, BaseItem? context, string? virtualFolderName = null)
     {
+        if (!string.IsNullOrEmpty(virtualFolderName))
+        {
+            return virtualFolderName;
+        }
+
         if (itemStubType.HasValue)
         {
             switch (itemStubType.Value)
@@ -696,8 +703,12 @@ public class DidlBuilder
     /// <param name="childCount">The child count.</param>
     /// <param name="filter">The <see cref="Filter"/>.</param>
     /// <param name="requestedId">The request id.</param>
+    /// <param name="virtualFolderName">The displayed virtual-folder name.</param>
+    /// <param name="idSuffix">The suffix encoded in this folder's object ID.</param>
+    /// <param name="contextStubType">The parent virtual-folder type.</param>
+    /// <param name="contextIdSuffix">The parent virtual-folder ID suffix.</param>
     /// </summary>
-    public void WriteFolderElement(XmlWriter writer, BaseItem folder, StubType? stubType, BaseItem? context, int childCount, Filter filter, string? requestedId = null)
+    public void WriteFolderElement(XmlWriter writer, BaseItem folder, StubType? stubType, BaseItem? context, int childCount, Filter filter, string? requestedId = null, string? virtualFolderName = null, string? idSuffix = null, StubType? contextStubType = null, string? contextIdSuffix = null)
     {
         writer.WriteStartElement(string.Empty, "container", NsDidl);
 
@@ -705,7 +716,7 @@ public class DidlBuilder
         writer.WriteAttributeString("searchable", "1");
         writer.WriteAttributeString("childCount", childCount.ToString(CultureInfo.InvariantCulture));
 
-        var clientId = GetClientId(folder, stubType);
+        var clientId = GetClientId(folder, stubType, idSuffix);
 
         if (string.Equals(requestedId, "0", StringComparison.Ordinal))
         {
@@ -718,7 +729,7 @@ public class DidlBuilder
 
             if (context is not null)
             {
-                writer.WriteAttributeString("parentID", GetClientId(context, null));
+                writer.WriteAttributeString("parentID", GetClientId(context, contextStubType, contextIdSuffix));
             }
             else
             {
@@ -734,7 +745,7 @@ public class DidlBuilder
             }
         }
 
-        AddGeneralProperties(folder, stubType, context, writer, filter);
+        AddGeneralProperties(folder, stubType, context, writer, filter, virtualFolderName);
 
         AddCover(folder, stubType, writer);
 
@@ -777,13 +788,13 @@ public class DidlBuilder
         }
     }
 
-    private void AddCommonFields(BaseItem item, StubType? itemStubType, BaseItem? context, XmlWriter writer, Filter filter)
+    private void AddCommonFields(BaseItem item, StubType? itemStubType, BaseItem? context, XmlWriter writer, Filter filter, string? virtualFolderName = null)
     {
         // Don't filter on dc:title because not all devices will include it in the filter
         // MediaMonkey for example won't display content without a title
         // if (filter.Contains("dc:title"))
         {
-            AddValue(writer, "dc", "title", GetDisplayName(item, itemStubType, context), NsDc);
+            AddValue(writer, "dc", "title", GetDisplayName(item, itemStubType, context, virtualFolderName), NsDc);
         }
 
         WriteObjectClass(writer, item, itemStubType);
@@ -959,9 +970,9 @@ public class DidlBuilder
         }
     }
 
-    private void AddGeneralProperties(BaseItem item, StubType? itemStubType, BaseItem? context, XmlWriter writer, Filter filter)
+    private void AddGeneralProperties(BaseItem item, StubType? itemStubType, BaseItem? context, XmlWriter writer, Filter filter, string? virtualFolderName = null)
     {
-        AddCommonFields(item, itemStubType, context, writer, filter);
+        AddCommonFields(item, itemStubType, context, writer, filter, virtualFolderName);
 
         var hasAlbumArtists = item as IHasAlbumArtist;
 
@@ -1253,10 +1264,11 @@ public class DidlBuilder
     /// </summary>
     /// <param name="item">The <see cref="BaseItem"/>.</param>
     /// <param name="stubType">Current <see cref="StubType"/>.</param>
+    /// <param name="idSuffix">The optional virtual-folder ID suffix.</param>
     /// <returns>The client id</returns>
-    public static string GetClientId(BaseItem item, StubType? stubType)
+    public static string GetClientId(BaseItem item, StubType? stubType, string? idSuffix = null)
     {
-        return GetClientId(item.Id, stubType);
+        return GetClientId(item.Id, stubType, idSuffix);
     }
 
     /// <summary>
@@ -1264,14 +1276,17 @@ public class DidlBuilder
     /// </summary>
     /// <param name="idValue">The <see cref="Guid"/>.</param>
     /// <param name="stubType">Current <see cref="StubType"/>.</param>
+    /// <param name="idSuffix">The optional virtual-folder ID suffix.</param>
     /// <returns>The client id</returns>
-    public static string GetClientId(Guid idValue, StubType? stubType)
+    public static string GetClientId(Guid idValue, StubType? stubType, string? idSuffix = null)
     {
         var id = idValue.ToString("N", CultureInfo.InvariantCulture);
 
         if (stubType.HasValue)
         {
-            id = stubType.Value.ToString().ToLowerInvariant() + "_" + id;
+            id = stubType.Value.ToString().ToLowerInvariant()
+                + (string.IsNullOrEmpty(idSuffix) ? string.Empty : "-" + idSuffix.ToLowerInvariant())
+                + "_" + id;
         }
 
         return id;


### PR DESCRIPTION
## Summary

Adds alphabetical virtual folders to the DLNA Movies and Series views.

Instead of returning every movie or series directly under the corresponding all-items folder, the plugin now presents:

* `#`
* `A` through `Z`

Opening one of these folders returns only movies or series whose sortable name falls within that bucket.

## Motivation

Large DLNA libraries can contain tens of thousands of items, and some television clients do not provide practical navigation for very large flat folder listings.

My Movies library contains approximately 33,000 files, which made it effectively impossible to scroll beyond the early entries. Adding an alphabetical folder layer makes the library usable without relying on client-side search support.

## Implementation

* Adds `MovieLetter` and `SeriesLetter` virtual stub types.
* Carries the selected alphabetical bucket through the DLNA object ID.
* Preserves the correct virtual parent and child IDs.
* Uses Jellyfin item-query name bounds so filtering and paging occur in the database query.
* Leaves Latest, Continue Watching, Next Up, Favorites, Genres, and Collections unchanged.
* Uses `#` for entries sorting before `A`, including numeric and punctuation-starting titles.

## Resulting hierarchy

```text
Movies
└── Movies
    ├── #
    ├── A
    ├── B
    └── ... Z

TV Shows
└── Shows
    ├── #
    ├── A
    ├── B
    └── ... Z
```

## Testing

* `dotnet build Jellyfin.Plugin.Dlna.sln`
* `dotnet test Jellyfin.Plugin.Dlna.sln`
* `git diff --check`
* Installed and tested the compiled plugin in Jellyfin.
* Verified `#` and `A–Z` folders appear under Movies and Shows.
* Verified opening a letter returns the expected movies or series.
* Verified series remain navigable through seasons and episodes.
* Verified the existing non-alphabetical views continue to work.

Closes #221
