### PR TITLE
Fix favorite filtering in normal DLNA browsing

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -876,10 +876,10 @@ public class ControlHandler : BaseControlHandler
     /// <param name="isFavorite">A value indicating whether to only fetch favorite items.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
     private QueryResult<ServerItem> GetChildrenOfItem(
-    BaseItem parent,
-    InternalItemsQuery query,
-    BaseItemKind itemType,
-    bool isFavorite = false)
+        BaseItem parent,
+        InternalItemsQuery query,
+        BaseItemKind itemType,
+        bool isFavorite = false)
     {
         query.Recursive = true;
         query.Parent = parent;

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -875,12 +875,20 @@ public class ControlHandler : BaseControlHandler
     /// <param name="itemType">The item type.</param>
     /// <param name="isFavorite">A value indicating whether to only fetch favorite items.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetChildrenOfItem(BaseItem parent, InternalItemsQuery query, BaseItemKind itemType, bool isFavorite = false)
+    private QueryResult<ServerItem> GetChildrenOfItem(
+    BaseItem parent,
+    InternalItemsQuery query,
+    BaseItemKind itemType,
+    bool isFavorite = false)
     {
         query.Recursive = true;
         query.Parent = parent;
-        query.IsFavorite = isFavorite;
         query.IncludeItemTypes = [itemType];
+
+        if (isFavorite)
+        {
+            query.IsFavorite = true;
+        }
 
         var result = _libraryManager.GetItemsResult(query);
 


### PR DESCRIPTION
## Summary

Fixes normal DLNA library browsing incorrectly filtering items based on favorite status.

`GetChildrenOfItem` previously assigned the non-nullable method argument directly to the nullable query property:

```csharp
query.IsFavorite = isFavorite;
```

Because `isFavorite` defaults to `false`, ordinary Movies, Series, Songs, and Albums views explicitly requested only items where `IsFavorite` is false.

In Jellyfin's query system, these values have distinct meanings:

* `null`: do not filter by favorite status
* `true`: return favorite items
* `false`: return only explicitly non-favorite items

Items without a corresponding `UserData` row could therefore be excluded from normal DLNA browse results.

## Change

Only apply the favorite filter when a favorite-specific folder is requested:

```csharp
if (isFavorite)
{
    query.IsFavorite = true;
}
```

Normal library folders now leave `query.IsFavorite` unset, while Favorite Movies, Favorite Series, Favorite Episodes, Favorite Albums, Favorite Artists, and Favorite Songs continue to request favorite items.

## Testing

* `dotnet build Jellyfin.Plugin.Dlna.sln`
* `dotnet test Jellyfin.Plugin.Dlna.sln`
* `git diff --check`
* Installed the compiled plugin in Jellyfin.
* Verified that a previously affected LG television now displays the full Movies listing instead of one movie.
* Verified Movies, Series, Genres, and other normal browse folders populate correctly.
* Verified favorite-specific folders continue to restrict results to favorites.

Closes #193
Closes #202

Addresses the `IsFavorite` filtering portion of #200.
