### PR TITLE
Update Panasonic Viera.xml

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/Profiles/Xml/Panasonic Viera.xml
+++ b/src/Jellyfin.Plugin.Dlna/Profiles/Xml/Panasonic Viera.xml
@@ -73,7 +73,7 @@
     </CodecProfile>
   </CodecProfiles>
   <ResponseProfiles>
-    <ResponseProfile container="ts,mpegts" type="Video" orgPn="MPEG_TS_SD_EU,MPEG_TS_SD_NA,MPEG_TS_SD_KO" mimeType="video/vnd.dlna.mpeg-tts">
+    <ResponseProfile container="ts" type="Video" orgPn="MPEG_TS_SD_KO" mimeType="video/vnd.dlna.mpeg-tts">
       <Conditions />
     </ResponseProfile>
     <ResponseProfile container="m4v" type="Video" mimeType="video/mp4">


### PR DESCRIPTION
Responseprofile for container="ts" should be changed, otherwise MPEG2-TS videos can't be played on the Panasonic Viera. The change was taken from this Emby forum which seemed to have fixed the issue. https://emby.media/community/topic/9460-dlna-transcoding-to-panasonic-viera-not-working/page/2/#comment-265499_wrap