### PR TITLE
Fixes for PlayTo

### DIFF
--- a/src/Jellyfin.Plugin.Dlna.Model/DlnaDeviceProfile.cs
+++ b/src/Jellyfin.Plugin.Dlna.Model/DlnaDeviceProfile.cs
@@ -173,7 +173,7 @@ public class DlnaDeviceProfile : DeviceProfile
     public MediaType[] FetchSupportedMediaTypes()
     {
         return ContainerHelper.Split(SupportedMediaTypes)
-            .Select(m => Enum.TryParse<MediaType>(m, out var parsed) ? parsed : MediaType.Unknown)
+            .Select(m => Enum.TryParse<MediaType>(m, true, out var parsed) ? parsed : MediaType.Unknown)
             .Where(m => m != MediaType.Unknown)
             .ToArray();
     }

--- a/src/Jellyfin.Plugin.Dlna/DlnaServiceRegistrator.cs
+++ b/src/Jellyfin.Plugin.Dlna/DlnaServiceRegistrator.cs
@@ -29,6 +29,8 @@ public class DlnaServiceRegistrator : IPluginServiceRegistrator
     {
         serviceCollection.AddHttpClient(NamedClient.Dlna, c =>
             {
+                c.Timeout = TimeSpan.FromSeconds(30);
+
                 c.DefaultRequestHeaders.UserAgent.ParseAdd(
                     string.Format(
                         CultureInfo.InvariantCulture,

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
@@ -1073,7 +1073,13 @@ public class Device : IDisposable
             return null;
         }
 
-        string url = NormalizeUrl(Properties.BaseUrl, avService.ScpdUrl);
+        bool append_dmr = true;
+        if (Properties.Manufacturer.Contains("xiaomi", StringComparison.OrdinalIgnoreCase))
+        {
+            append_dmr = false;
+        }
+
+        string url = NormalizeUrl(Properties.BaseUrl, avService.ScpdUrl, append_dmr);
 
         var httpClient = new DlnaHttpClient(_logger, _httpClientFactory);
 
@@ -1099,10 +1105,14 @@ public class Device : IDisposable
         var avService = GetServiceRenderingControl();
         ArgumentNullException.ThrowIfNull(avService);
 
-        string url = NormalizeUrl(Properties.BaseUrl, avService.ScpdUrl);
+        bool append_dmr = true;
+        if (Properties.Manufacturer.Contains("xiaomi", StringComparison.OrdinalIgnoreCase))
+        {
+            append_dmr = false;
+        }
+        string url = NormalizeUrl(Properties.BaseUrl, avService.ScpdUrl, append_dmr);
 
         var httpClient = new DlnaHttpClient(_logger, _httpClientFactory);
-        _logger.LogDebug("Dlna Device.GetRenderingProtocolAsync");
         var document = await httpClient.GetDataAsync(url, cancellationToken).ConfigureAwait(false);
         if (document is null)
         {
@@ -1113,7 +1123,7 @@ public class Device : IDisposable
         return RendererCommands;
     }
 
-    private static string NormalizeUrl(string baseUrl, string url)
+    private static string NormalizeUrl(string baseUrl, string url, bool append_dmr = true)
     {
         // If it's already a complete url, don't stick anything onto the front of it
         if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
@@ -1121,7 +1131,7 @@ public class Device : IDisposable
             return url;
         }
 
-        if (!url.Contains('/', StringComparison.Ordinal))
+        if (append_dmr && !url.Contains('/', StringComparison.Ordinal))
         {
             url = "/dmr/" + url;
         }

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Security;
 using System.Threading;
@@ -319,7 +320,7 @@ public class Device : IDisposable
 
         await new DlnaHttpClient(_logger, _httpClientFactory)
             .SendCommandAsync(
-                Properties.BaseUrl,
+                NormalizeUrl(service.ControlUrl),
                 service,
                 command.Name,
                 rendererCommands!.BuildPost(command, service.ServiceType, value), // null checked above
@@ -355,7 +356,7 @@ public class Device : IDisposable
 
         await new DlnaHttpClient(_logger, _httpClientFactory)
             .SendCommandAsync(
-                Properties.BaseUrl,
+                NormalizeUrl(service.ControlUrl),
                 service,
                 command.Name,
                 rendererCommands!.BuildPost(command, service.ServiceType, value), // null checked above
@@ -382,7 +383,7 @@ public class Device : IDisposable
         var service = GetAvTransportService() ?? throw new InvalidOperationException("Unable to find service");
         await new DlnaHttpClient(_logger, _httpClientFactory)
             .SendCommandAsync(
-                Properties.BaseUrl,
+                NormalizeUrl(service.ControlUrl),
                 service,
                 command.Name,
                 avCommands!.BuildPost(command, service.ServiceType, string.Format(CultureInfo.InvariantCulture, "{0:hh}:{0:mm}:{0:ss}", value), "REL_TIME"), // null checked above
@@ -422,9 +423,10 @@ public class Device : IDisposable
 
         var service = GetAvTransportService() ?? throw new InvalidOperationException("Unable to find service");
         var post = avCommands!.BuildPost(command, service.ServiceType, url, dictionary); // null checked above
+
         await new DlnaHttpClient(_logger, _httpClientFactory)
             .SendCommandAsync(
-                Properties.BaseUrl,
+                NormalizeUrl(service.ControlUrl),
                 service,
                 command.Name,
                 post,
@@ -482,7 +484,7 @@ public class Device : IDisposable
         var service = GetAvTransportService() ?? throw new InvalidOperationException("Unable to find service");
         var post = avCommands!.BuildPost(command, service.ServiceType, url, dictionary); // null checked above
         await new DlnaHttpClient(_logger, _httpClientFactory)
-            .SendCommandAsync(Properties.BaseUrl, service, command.Name, post, header, cancellationToken)
+            .SendCommandAsync(NormalizeUrl(service.ControlUrl), service, command.Name, post, header, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -506,7 +508,7 @@ public class Device : IDisposable
 
         var service = GetAvTransportService() ?? throw new InvalidOperationException("Unable to find service");
         return new DlnaHttpClient(_logger, _httpClientFactory).SendCommandAsync(
-            Properties.BaseUrl,
+            NormalizeUrl(service.ControlUrl),
             service,
             command.Name,
             avCommands.BuildPost(command, service.ServiceType, 1),
@@ -549,7 +551,7 @@ public class Device : IDisposable
         var service = GetAvTransportService() ?? throw new InvalidOperationException("Unable to find service");
         await new DlnaHttpClient(_logger, _httpClientFactory)
             .SendCommandAsync(
-                Properties.BaseUrl,
+                NormalizeUrl(service.ControlUrl),
                 service,
                 command.Name,
                 avCommands!.BuildPost(command, service.ServiceType, 1), // null checked above
@@ -577,7 +579,7 @@ public class Device : IDisposable
         var service = GetAvTransportService() ?? throw new InvalidOperationException("Unable to find service");
         await new DlnaHttpClient(_logger, _httpClientFactory)
             .SendCommandAsync(
-                Properties.BaseUrl,
+                NormalizeUrl(service.ControlUrl),
                 service,
                 command.Name,
                 avCommands!.BuildPost(command, service.ServiceType, 1), // null checked above
@@ -709,7 +711,7 @@ public class Device : IDisposable
         }
 
         var result = await new DlnaHttpClient(_logger, _httpClientFactory).SendCommandAsync(
-            Properties.BaseUrl,
+            NormalizeUrl(service.ControlUrl),
             service,
             command.Name,
             rendererCommands!.BuildPost(command, service.ServiceType), // null checked above
@@ -759,7 +761,7 @@ public class Device : IDisposable
         }
 
         var result = await new DlnaHttpClient(_logger, _httpClientFactory).SendCommandAsync(
-            Properties.BaseUrl,
+            NormalizeUrl(service.ControlUrl),
             service,
             command.Name,
             rendererCommands!.BuildPost(command, service.ServiceType), // null checked above
@@ -792,7 +794,7 @@ public class Device : IDisposable
         }
 
         var result = await new DlnaHttpClient(_logger, _httpClientFactory).SendCommandAsync(
-            Properties.BaseUrl,
+            NormalizeUrl(service.ControlUrl),
             service,
             command.Name,
             avCommands.BuildPost(command, service.ServiceType),
@@ -838,7 +840,7 @@ public class Device : IDisposable
         }
 
         var result = await new DlnaHttpClient(_logger, _httpClientFactory).SendCommandAsync(
-            Properties.BaseUrl,
+            NormalizeUrl(service.ControlUrl),
             service,
             command.Name,
             rendererCommands.BuildPost(command, service.ServiceType),
@@ -910,7 +912,7 @@ public class Device : IDisposable
         }
 
         var result = await new DlnaHttpClient(_logger, _httpClientFactory).SendCommandAsync(
-            Properties.BaseUrl,
+            NormalizeUrl(service.ControlUrl),
             service,
             command.Name,
             rendererCommands.BuildPost(command, service.ServiceType),
@@ -1073,17 +1075,7 @@ public class Device : IDisposable
             return null;
         }
 
-        bool append_dmr = true;
-        if (Properties.Manufacturer.Contains("xiaomi", StringComparison.OrdinalIgnoreCase))
-        {
-            append_dmr = false;
-        }
-
-        string url = NormalizeUrl(Properties.BaseUrl, avService.ScpdUrl, append_dmr);
-
-        var httpClient = new DlnaHttpClient(_logger, _httpClientFactory);
-
-        var document = await httpClient.GetDataAsync(url, cancellationToken).ConfigureAwait(false);
+        var document = await GetServiceDescriptionAsync(avService, cancellationToken).ConfigureAwait(false);
         if (document is null)
         {
             return null;
@@ -1105,15 +1097,7 @@ public class Device : IDisposable
         var avService = GetServiceRenderingControl();
         ArgumentNullException.ThrowIfNull(avService);
 
-        bool append_dmr = true;
-        if (Properties.Manufacturer.Contains("xiaomi", StringComparison.OrdinalIgnoreCase))
-        {
-            append_dmr = false;
-        }
-        string url = NormalizeUrl(Properties.BaseUrl, avService.ScpdUrl, append_dmr);
-
-        var httpClient = new DlnaHttpClient(_logger, _httpClientFactory);
-        var document = await httpClient.GetDataAsync(url, cancellationToken).ConfigureAwait(false);
+        var document = await GetServiceDescriptionAsync(avService, cancellationToken).ConfigureAwait(false);
         if (document is null)
         {
             return null;
@@ -1123,7 +1107,47 @@ public class Device : IDisposable
         return RendererCommands;
     }
 
-    private static string NormalizeUrl(string baseUrl, string url, bool append_dmr = true)
+    /// <summary>
+    /// Fetches the description of a service, retrying below <c>/dmr/</c> if the device does not serve it
+    /// at the location its description points to.
+    /// </summary>
+    /// <param name="service">The <see cref="DeviceService"/>.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+    /// <returns>The service description, or <c>null</c> if it could not be parsed.</returns>
+    private async Task<XDocument?> GetServiceDescriptionAsync(DeviceService service, CancellationToken cancellationToken)
+    {
+        var httpClient = new DlnaHttpClient(_logger, _httpClientFactory);
+        var url = NormalizeUrl(service.ScpdUrl);
+
+        try
+        {
+            return await httpClient.GetDataAsync(url, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            var fallbackUrl = GetDmrFallbackUrl(service.ScpdUrl);
+            if (fallbackUrl is null || string.Equals(fallbackUrl, url, StringComparison.Ordinal))
+            {
+                throw;
+            }
+
+            _logger.LogDebug(
+                ex,
+                "{Name} - no service description at {Url}, retrying at {FallbackUrl}",
+                Properties.Name,
+                url,
+                fallbackUrl);
+
+            return await httpClient.GetDataAsync(fallbackUrl, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Resolves a URL of the device description against its base URL.
+    /// </summary>
+    /// <param name="url">The URL to resolve.</param>
+    /// <returns>The absolute URL.</returns>
+    private string NormalizeUrl(string url)
     {
         // If it's already a complete url, don't stick anything onto the front of it
         if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
@@ -1131,9 +1155,11 @@ public class Device : IDisposable
             return url;
         }
 
-        if (append_dmr && !url.Contains('/', StringComparison.Ordinal))
+        // UPnP Device Architecture 1.0 section 2.1: relative URLs are resolved against the base URL,
+        // so a URL without a leading slash points next to the description, not to the server root.
+        if (Properties.BaseUri is not null && Uri.TryCreate(Properties.BaseUri, url, out var resolved))
         {
-            url = "/dmr/" + url;
+            return resolved.ToString();
         }
 
         if (!url.StartsWith('/'))
@@ -1141,7 +1167,22 @@ public class Device : IDisposable
             url = "/" + url;
         }
 
-        return baseUrl + url;
+        return Properties.BaseUrl + url;
+    }
+
+    /// <summary>
+    /// Gets the URL below <c>/dmr/</c> some devices serve their service descriptions from, without advertising it.
+    /// </summary>
+    /// <param name="url">The URL of the device description.</param>
+    /// <returns>The fallback URL, or <c>null</c> if it does not apply to <paramref name="url"/>.</returns>
+    private string? GetDmrFallbackUrl(string url)
+    {
+        if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase) || url.Contains('/', StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return Properties.BaseUrl + "/dmr/" + url;
     }
 
     /// <summary>
@@ -1180,6 +1221,7 @@ public class Device : IDisposable
         {
             Name = string.Join(' ', friendlyNames),
             BaseUrl = string.Format(CultureInfo.InvariantCulture, "http://{0}:{1}", url.Host, url.Port),
+            BaseUri = GetDescriptionBaseUri(document, url),
             Services = GetServices(document)
         };
 
@@ -1244,6 +1286,30 @@ public class Device : IDisposable
         }
 
         return new Device(deviceProperties, httpClientFactory, logger);
+    }
+
+    /// <summary>
+    /// Gets the base <see cref="Uri"/> the relative URLs of a device description resolve against.
+    /// </summary>
+    /// <param name="document">The device description.</param>
+    /// <param name="descriptionUrl">The <see cref="Uri"/> the description was retrieved from.</param>
+    /// <returns>The base <see cref="Uri"/>.</returns>
+    private static Uri GetDescriptionBaseUri(XDocument document, Uri descriptionUrl)
+    {
+        // UPnP Device Architecture 1.0 section 2.1: URLBase takes precedence over the retrieval URL if present.
+        var urlBase = document.Descendants(UPnpNamespaces.Ud.GetName("URLBase")).FirstOrDefault()?.Value.Trim();
+        if (!string.IsNullOrEmpty(urlBase) && Uri.TryCreate(urlBase, UriKind.Absolute, out var baseUri))
+        {
+            // URLBase denotes a directory and is specified to end with a slash, but not all devices honor that.
+            if (!baseUri.AbsolutePath.EndsWith('/'))
+            {
+                baseUri = new Uri(baseUri, baseUri.AbsolutePath + "/");
+            }
+
+            return baseUri;
+        }
+
+        return descriptionUrl;
     }
 
     private static DeviceIcon CreateIcon(XElement element)

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
@@ -424,6 +424,19 @@ public class Device : IDisposable
         var service = GetAvTransportService() ?? throw new InvalidOperationException("Unable to find service");
         var post = avCommands!.BuildPost(command, service.ServiceType, url, dictionary); // null checked above
 
+        // AVTransport:1 section 2.4.2 defines SetAVTransportURI for the STOPPED and NO_MEDIA_PRESENT states only.
+        // A renderer that is still playing, e.g. because it was stopped from its own remote, answers every
+        // following request with 705 (Transport is locked) until it is stopped.
+        try
+        {
+            await SetStop(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Stopping a transport that is already idle is a no-op that some devices fault on
+            _logger.LogDebug(ex, "{Name} - Stop before SetAVTransportURI failed", Properties.Name);
+        }
+
         await new DlnaHttpClient(_logger, _httpClientFactory)
             .SendCommandAsync(
                 NormalizeUrl(service.ControlUrl),

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
@@ -79,11 +79,7 @@ public class Device : IDisposable
     /// </summary>
     public int Volume
     {
-        get
-        {
-            RefreshVolumeIfNeeded().GetAwaiter().GetResult();
-            return _volume;
-        }
+        get => _volume;
 
         set => _volume = value;
     }
@@ -616,6 +612,8 @@ public class Device : IDisposable
         try
         {
             var cancellationToken = CancellationToken.None;
+
+            await RefreshVolumeIfNeeded().ConfigureAwait(false);
 
             var avCommands = await GetAVProtocolAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
@@ -473,8 +473,8 @@ public class Device : IDisposable
     /// SetNextAvTransport is used to specify to the DLNA device what is the next track to play.
     /// Without that information, the next track command on the device does not work.
     /// </remarks>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public async Task SetNextAvTransport(string url, string? header, string metaData, CancellationToken cancellationToken = default)
+    /// <returns><c>true</c> if the device was told about the next track; otherwise, <c>false</c>.</returns>
+    public async Task<bool> SetNextAvTransport(string url, string? header, string metaData, CancellationToken cancellationToken = default)
     {
         var avCommands = await GetAVProtocolAsync(cancellationToken).ConfigureAwait(false);
 
@@ -485,7 +485,7 @@ public class Device : IDisposable
         var command = avCommands?.ServiceActions.FirstOrDefault(c => string.Equals(c.Name, "SetNextAVTransportURI", StringComparison.OrdinalIgnoreCase));
         if (command is null)
         {
-            return;
+            return false;
         }
 
         var dictionary = new Dictionary<string, string>
@@ -499,6 +499,8 @@ public class Device : IDisposable
         await new DlnaHttpClient(_logger, _httpClientFactory)
             .SendCommandAsync(NormalizeUrl(service.ControlUrl), service, command.Name, post, header, cancellationToken)
             .ConfigureAwait(false);
+
+        return true;
     }
 
     private static string CreateDidlMeta(string value)

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/DeviceInfo.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/DeviceInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.Dlna.Common;
 using Jellyfin.Plugin.Dlna.Model;
@@ -87,6 +88,16 @@ public class DeviceInfo
         get => _baseUrl;
         set => _baseUrl = value;
     }
+
+    /// <summary>
+    /// Gets or sets the base <see cref="Uri"/> that relative URLs of the device description are resolved against.
+    /// </summary>
+    /// <remarks>
+    /// This is the <c>URLBase</c> element of the device description if it provides one, otherwise the URL the
+    /// description was retrieved from, as required by the UPnP Device Architecture. Unlike <see cref="BaseUrl"/>
+    /// it keeps the path of the description, so relative URLs resolve to the directory serving the description.
+    /// </remarks>
+    public Uri? BaseUri { get; set; }
 
     /// <summary>
     /// Gets or sets the icon.

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/DlnaHttpClient.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/DlnaHttpClient.cs
@@ -37,22 +37,6 @@ public partial class DlnaHttpClient
     [GeneratedRegex("(&(?![a-z]*;))")]
     private static partial Regex EscapeAmpersandRegex();
 
-    private static string NormalizeServiceUrl(string baseUrl, string serviceUrl)
-    {
-        // If it's already a complete url, don't stick anything onto the front of it
-        if (serviceUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-        {
-            return serviceUrl;
-        }
-
-        if (!serviceUrl.StartsWith('/'))
-        {
-            serviceUrl = "/" + serviceUrl;
-        }
-
-        return baseUrl + serviceUrl;
-    }
-
     private async Task<XDocument?> SendRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var client = _httpClientFactory.CreateClient(NamedClient.Dlna);
@@ -115,7 +99,7 @@ public partial class DlnaHttpClient
     /// <summary>
     /// Sends command async.
     /// </summary>
-    /// <param name="baseUrl">The base URL.</param>
+    /// <param name="controlUrl">The absolute control URL of the service.</param>
     /// <param name="service">The <see cref="DeviceService"/>.</param>
     /// <param name="command">The command.</param>
     /// <param name="postData">The POST data.</param>
@@ -123,14 +107,14 @@ public partial class DlnaHttpClient
     /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous send operation.</returns>
     public async Task<XDocument?> SendCommandAsync(
-        string baseUrl,
+        string controlUrl,
         DeviceService service,
         string command,
         string postData,
         string? header = null,
         CancellationToken cancellationToken = default)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Post, NormalizeServiceUrl(baseUrl, service.ControlUrl))
+        using var request = new HttpRequestMessage(HttpMethod.Post, controlUrl)
         {
             Content = new StringContent(postData, Encoding.UTF8, MediaTypeNames.Text.Xml)
         };

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/DlnaHttpClient.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/DlnaHttpClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
@@ -20,6 +21,8 @@ namespace Jellyfin.Plugin.Dlna.PlayTo;
 /// </summary>
 public partial class DlnaHttpClient
 {
+    private const int MaxLoggedContentLength = 1024;
+
     private readonly ILogger _logger;
     private readonly IHttpClientFactory _httpClientFactory;
 
@@ -37,10 +40,95 @@ public partial class DlnaHttpClient
     [GeneratedRegex("(&(?![a-z]*;))")]
     private static partial Regex EscapeAmpersandRegex();
 
+    /// <summary>
+    /// Logs what a device answered to a request it refused.
+    /// </summary>
+    /// <remarks>
+    /// The status code alone does not say why a device rejected a command: the reason is in the SOAP fault
+    /// it returns, which would otherwise be dropped with the response.
+    /// </remarks>
+    /// <param name="request">The <see cref="HttpRequestMessage"/> that was refused.</param>
+    /// <param name="response">The <see cref="HttpResponseMessage"/> of the device.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    private async Task LogErrorResponseAsync(HttpRequestMessage request, HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        string content;
+        try
+        {
+            content = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                "Device answered {StatusCode} to {Method} {Uri}, the response could not be read: {Message}",
+                (int)response.StatusCode,
+                request.Method,
+                request.RequestUri,
+                ex.Message);
+
+            return;
+        }
+
+        var (errorCode, errorDescription) = GetUPnPError(content);
+        if (errorCode is not null)
+        {
+            _logger.LogWarning(
+                "Device answered {StatusCode} to {Method} {Uri} with UPnP error {ErrorCode}: {ErrorDescription}",
+                (int)response.StatusCode,
+                request.Method,
+                request.RequestUri,
+                errorCode,
+                errorDescription ?? "no description");
+
+            return;
+        }
+
+        _logger.LogWarning(
+            "Device answered {StatusCode} to {Method} {Uri}: {Content}",
+            (int)response.StatusCode,
+            request.Method,
+            request.RequestUri,
+            content.Length > MaxLoggedContentLength ? content[..MaxLoggedContentLength] + "..." : content);
+    }
+
+    /// <summary>
+    /// Gets the UPnP error a device reported in a SOAP fault.
+    /// </summary>
+    /// <param name="content">The response content.</param>
+    /// <returns>The error code and description, both <c>null</c> if the content carries no UPnP error.</returns>
+    private static (string? ErrorCode, string? ErrorDescription) GetUPnPError(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return (null, null);
+        }
+
+        try
+        {
+            var document = XDocument.Parse(content);
+
+            // The fault is wrapped in SOAP envelope and detail elements, so go by name only.
+            var errorCode = document.Descendants().FirstOrDefault(e => string.Equals(e.Name.LocalName, "errorCode", StringComparison.Ordinal))?.Value;
+            var errorDescription = document.Descendants().FirstOrDefault(e => string.Equals(e.Name.LocalName, "errorDescription", StringComparison.Ordinal))?.Value;
+
+            return (errorCode, errorDescription);
+        }
+        catch (XmlException)
+        {
+            return (null, null);
+        }
+    }
+
     private async Task<XDocument?> SendRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var client = _httpClientFactory.CreateClient(NamedClient.Dlna);
         using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            await LogErrorResponseAsync(request, response, cancellationToken).ConfigureAwait(false);
+        }
+
         response.EnsureSuccessStatusCode();
         Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         await using (stream.ConfigureAwait(false))

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
@@ -931,16 +931,33 @@ public class PlayToSession : ISessionController, IDisposable
         }
     }
 
+    /// <summary>
+    /// Waits for the renderer to start playing what was just set as its transport, then seeks to the requested position.
+    /// </summary>
+    /// <param name="positionTicks">The position to seek to.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     private async Task SeekAfterTransportChange(long positionTicks, CancellationToken cancellationToken)
     {
-        const int MaxWait = 15000000;
-        const int Interval = 500;
+        var maxWait = TimeSpan.FromSeconds(15);
+        var interval = TimeSpan.FromMilliseconds(500);
 
-        var currentWait = 0;
-        while (_device.TransportState != TransportState.PLAYING && currentWait < MaxWait)
+        var waited = TimeSpan.Zero;
+        while (_device.TransportState != TransportState.PLAYING)
         {
-            await Task.Delay(Interval, cancellationToken).ConfigureAwait(false);
-            currentWait += Interval;
+            if (waited >= maxWait)
+            {
+                _logger.LogWarning(
+                    "{DeviceName} did not start playing within {Seconds}s of the transport change, not seeking to {Position}",
+                    _session.DeviceName,
+                    maxWait.TotalSeconds,
+                    TimeSpan.FromTicks(positionTicks));
+
+                return;
+            }
+
+            await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+            waited += interval;
         }
 
         await _device.Seek(TimeSpan.FromTicks(positionTicks), cancellationToken).ConfigureAwait(false);

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
@@ -55,6 +55,7 @@ public class PlayToSession : ISessionController, IDisposable
     private readonly List<PlaylistItem> _playlist = [];
     private Device _device;
     private int _currentPlaylistIndex;
+    private int _nextTrackIndex = -1;
     private bool _disposed;
 
     /// <summary>
@@ -134,6 +135,8 @@ public class PlayToSession : ISessionController, IDisposable
      */
     private async Task SendNextTrackMessage(int currentPlayListItemIndex, CancellationToken cancellationToken)
     {
+        _nextTrackIndex = -1;
+
         if (currentPlayListItemIndex >= 0 && currentPlayListItemIndex < _playlist.Count - 1)
         {
             // The current playing item is indeed in the play list and we are not yet at the end of the playlist.
@@ -145,8 +148,12 @@ public class PlayToSession : ISessionController, IDisposable
                 return;
             }
 
-            // Send the SetNextAvTransport message.
-            await _device.SetNextAvTransport(nextItem.StreamUrl, GetDlnaHeaders(nextItem), nextItem.Didl, cancellationToken).ConfigureAwait(false);
+            // Send the SetNextAvTransport message. A device that accepts it advances to that track by
+            // itself, which OnDevicePlaybackStopped has to know about to not advance the playlist again.
+            if (await _device.SetNextAvTransport(nextItem.StreamUrl, GetDlnaHeaders(nextItem), nextItem.Didl, cancellationToken).ConfigureAwait(false))
+            {
+                _nextTrackIndex = nextItemIndex;
+            }
         }
     }
 
@@ -258,11 +265,25 @@ public class PlayToSession : ISessionController, IDisposable
 
             if (playedToCompletion)
             {
-                await SetPlaylistIndex(_currentPlaylistIndex + 1).ConfigureAwait(false);
+                var nextIndex = _currentPlaylistIndex + 1;
+
+                // The device was handed this track with SetNextAVTransportURI and moves to it on its own.
+                // Sending it again restarts the track the device is already playing, or skips the one after it.
+                if (_nextTrackIndex == nextIndex)
+                {
+                    _logger.LogDebug(
+                        "{DeviceName} - Not advancing the playlist, the device moves to track {NextIndex} on its own",
+                        _session.DeviceName,
+                        nextIndex);
+
+                    return;
+                }
+
+                await SetPlaylistIndex(nextIndex).ConfigureAwait(false);
             }
             else
             {
-                _playlist.Clear();
+                ClearPlaylist();
             }
         }
         catch (Exception ex)
@@ -486,7 +507,7 @@ public class PlayToSession : ISessionController, IDisposable
         switch (command.Command)
         {
             case PlaystateCommand.Stop:
-                _playlist.Clear();
+                ClearPlaylist();
                 return _device.SetStop(CancellationToken.None);
 
             case PlaystateCommand.Pause:
@@ -711,7 +732,7 @@ public class PlayToSession : ISessionController, IDisposable
     /// <returns><c>true</c> on success.</returns>
     private async Task<bool> PlayItems(IEnumerable<PlaylistItem> items, CancellationToken cancellationToken = default)
     {
-        _playlist.Clear();
+        ClearPlaylist();
         _playlist.AddRange(items);
         _logger.LogDebug("{0} - Playing {1} items", _session.DeviceName, _playlist.Count);
 
@@ -719,11 +740,17 @@ public class PlayToSession : ISessionController, IDisposable
         return true;
     }
 
+    private void ClearPlaylist()
+    {
+        _playlist.Clear();
+        _nextTrackIndex = -1;
+    }
+
     private async Task SetPlaylistIndex(int index, CancellationToken cancellationToken = default)
     {
         if (index < 0 || index >= _playlist.Count)
         {
-            _playlist.Clear();
+            ClearPlaylist();
             await _device.SetStop(cancellationToken).ConfigureAwait(false);
             return;
         }

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
@@ -36,6 +36,8 @@ namespace Jellyfin.Plugin.Dlna.PlayTo;
 /// </summary>
 public class PlayToSession : ISessionController, IDisposable
 {
+    private static readonly MediaType[] _playableMediaTypes = [MediaType.Audio, MediaType.Video, MediaType.Photo];
+
     private readonly SessionInfo _session;
     private readonly ISessionManager _sessionManager;
     private readonly ILibraryManager _libraryManager;
@@ -388,15 +390,29 @@ public class PlayToSession : ISessionController, IDisposable
             ? null :
             _userManager.GetUserById(command.ControllingUserId);
 
+        var profile = GetProfile();
+
+        // A profile can name any media type, but only the ones GetPlaylistItem knows can be played
+        var supportedMediaTypes = profile.FetchSupportedMediaTypes().Intersect(_playableMediaTypes).ToArray();
+
+        if (supportedMediaTypes.Length == 0)
+        {
+            _logger.LogWarning(
+                "{DeviceName} - Profile {ProfileName} declares no playable media type in \"{SupportedMediaTypes}\", nothing can be played",
+                _session.DeviceName,
+                profile.Name,
+                profile.SupportedMediaTypes);
+        }
+
         var items = new List<BaseItem>();
         foreach (var id in command.ItemIds)
         {
-            AddItemFromId(id, items);
+            AddItemFromId(id, supportedMediaTypes, items);
         }
 
         var startIndex = command.StartIndex ?? 0;
 
-        if (startIndex > items.Count)
+        if (startIndex >= items.Count)
         {
             _logger.LogDebug("{DeviceName} - Play command resulted in no items", _session.DeviceName);
             return Task.CompletedTask;
@@ -417,11 +433,12 @@ public class PlayToSession : ISessionController, IDisposable
             command.StartPositionTicks ?? 0,
             command.MediaSourceId ?? string.Empty,
             command.AudioStreamIndex,
-            command.SubtitleStreamIndex);
+            command.SubtitleStreamIndex,
+            profile);
 
         for (int i = 1; i < len; i++)
         {
-            playlist[i] = CreatePlaylistItem(items[i], user, 0, string.Empty, null, null);
+            playlist[i] = CreatePlaylistItem(items[i], user, 0, string.Empty, null, null, profile);
         }
 
         _logger.LogDebug("{0} - Playlist created", _session.DeviceName);
@@ -493,7 +510,7 @@ public class PlayToSession : ISessionController, IDisposable
                 var user = _session.UserId.IsEmpty()
                     ? null
                     : _userManager.GetUserById(_session.UserId);
-                var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, info.AudioStreamIndex, info.SubtitleStreamIndex);
+                var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, info.AudioStreamIndex, info.SubtitleStreamIndex, GetProfile());
 
                 await _device.SetAvTransport(newItem.StreamUrl, GetDlnaHeaders(newItem), newItem.Didl, CancellationToken.None).ConfigureAwait(false);
 
@@ -518,14 +535,30 @@ public class PlayToSession : ISessionController, IDisposable
         return info.IsDirectStream;
     }
 
-    private void AddItemFromId(Guid id, List<BaseItem> list)
+    private void AddItemFromId(Guid id, IReadOnlyCollection<MediaType> supportedMediaTypes, List<BaseItem> list)
     {
         var item = _libraryManager.GetItemById(id);
-        if (item?.MediaType == MediaType.Audio || item?.MediaType == MediaType.Video)
+        if (item is null)
         {
-            list.Add(item);
+            return;
         }
+
+        if (!supportedMediaTypes.Contains(item.MediaType))
+        {
+            _logger.LogDebug(
+                "{DeviceName} - Skipping {ItemName}, the device does not support {MediaType}",
+                _session.DeviceName,
+                item.Name,
+                item.MediaType);
+
+            return;
+        }
+
+        list.Add(item);
     }
+
+    private DlnaDeviceProfile GetProfile()
+        => _dlnaManager.GetProfile(_device.Properties.ToDeviceIdentification()) ?? _dlnaManager.GetDefaultProfile();
 
     private PlaylistItem CreatePlaylistItem(
         BaseItem item,
@@ -533,13 +566,9 @@ public class PlayToSession : ISessionController, IDisposable
         long startPostionTicks,
         string? mediaSourceId,
         int? audioStreamIndex,
-        int? subtitleStreamIndex)
+        int? subtitleStreamIndex,
+        DlnaDeviceProfile profile)
     {
-        var deviceInfo = _device.Properties;
-
-        var profile = _dlnaManager.GetProfile(deviceInfo.ToDeviceIdentification()) ??
-                      _dlnaManager.GetDefaultProfile();
-
         var mediaSources = item is IHasMediaSources
             ? _mediaSourceManager.GetStaticMediaSources(item, true, user).ToArray()
             : [];
@@ -802,7 +831,7 @@ public class PlayToSession : ISessionController, IDisposable
                 var user = _session.UserId.IsEmpty()
                     ? null
                     : _userManager.GetUserById(_session.UserId);
-                var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, newIndex, info.SubtitleStreamIndex);
+                var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, newIndex, info.SubtitleStreamIndex, GetProfile());
 
                 await _device.SetAvTransport(newItem.StreamUrl, GetDlnaHeaders(newItem), newItem.Didl, CancellationToken.None).ConfigureAwait(false);
 
@@ -833,7 +862,7 @@ public class PlayToSession : ISessionController, IDisposable
                 var user = _session.UserId.IsEmpty()
                     ? null
                     : _userManager.GetUserById(_session.UserId);
-                var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, info.AudioStreamIndex, newIndex);
+                var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, info.AudioStreamIndex, newIndex, GetProfile());
 
                 await _device.SetAvTransport(newItem.StreamUrl, GetDlnaHeaders(newItem), newItem.Didl, CancellationToken.None).ConfigureAwait(false);
 

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
@@ -148,11 +148,23 @@ public class PlayToSession : ISessionController, IDisposable
                 return;
             }
 
-            // Send the SetNextAvTransport message. A device that accepts it advances to that track by
-            // itself, which OnDevicePlaybackStopped has to know about to not advance the playlist again.
-            if (await _device.SetNextAvTransport(nextItem.StreamUrl, GetDlnaHeaders(nextItem), nextItem.Didl, cancellationToken).ConfigureAwait(false))
+            try
             {
-                _nextTrackIndex = nextItemIndex;
+                // Send the SetNextAvTransport message. A device that accepts it advances to that track by
+                // itself, which OnDevicePlaybackStopped has to know about to not advance the playlist again.
+                if (await _device.SetNextAvTransport(nextItem.StreamUrl, GetDlnaHeaders(nextItem), nextItem.Didl, cancellationToken).ConfigureAwait(false))
+                {
+                    _nextTrackIndex = nextItemIndex;
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Announcing the next track is optional, so a device that refuses it must not fail playback of
+                // the current one. The playlist is advanced by the server instead, _nextTrackIndex stays unset.
+                _logger.LogWarning(
+                    ex,
+                    "{DeviceName} - Failed to announce the next track, the server will advance the playlist itself",
+                    _session.DeviceName);
             }
         }
     }

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
@@ -443,16 +443,6 @@ public class PlayToSession : ISessionController, IDisposable
 
         _logger.LogDebug("{0} - Playlist created", _session.DeviceName);
 
-        if (command.PlayCommand == PlayCommand.PlayLast)
-        {
-            _playlist.AddRange(playlist);
-        }
-
-        if (command.PlayCommand == PlayCommand.PlayNext)
-        {
-            _playlist.AddRange(playlist);
-        }
-
         if (!command.ControllingUserId.IsEmpty())
         {
             _sessionManager.LogSessionActivity(
@@ -462,6 +452,30 @@ public class PlayToSession : ISessionController, IDisposable
                 _session.DeviceName,
                 _session.RemoteEndPoint,
                 user);
+        }
+
+        // Queueing only applies while there is a playlist to queue onto, an empty one just starts playing
+        if (_playlist.Count > 0
+            && (command.PlayCommand == PlayCommand.PlayLast || command.PlayCommand == PlayCommand.PlayNext))
+        {
+            if (command.PlayCommand == PlayCommand.PlayLast)
+            {
+                _playlist.AddRange(playlist);
+            }
+            else
+            {
+                _playlist.InsertRange(Math.Clamp(_currentPlaylistIndex + 1, 0, _playlist.Count), playlist);
+            }
+
+            _logger.LogDebug(
+                "{DeviceName} - {PlayCommand} queued {Count} items, playlist holds {Total}",
+                _session.DeviceName,
+                command.PlayCommand,
+                playlist.Length,
+                _playlist.Count);
+
+            // The item following the one that is playing may have changed, so tell the device about it again
+            return SendNextTrackMessage(_currentPlaylistIndex, cancellationToken);
         }
 
         return PlayItems(playlist, cancellationToken);


### PR DESCRIPTION
* Applies the patch from #153
* PlayTo now sends stop before `SetAVTransportURI`
* Resolve `SCPD` URL  against the description document's base URL
* Do not advance the playlist when the device advances on its own
* Play only the media types the device profile supports
* Queue PlayNext and PlayLast instead of restarting the playlist
* Wrap `SendNextTrackMessag` so it does not bort playback on failure
* Additional logging so we can diagnose issues better

Fixes #12
Fixes #24
Fixes #39
Fixes #153

Partial or potentially full fixes for #71, #102, #11, #118, #26