### PR TITLE
Fix DLNA browsing, search and device discovery

### DIFF
--- a/src/Jellyfin.Plugin.Dlna.Model/SearchCriteria.cs
+++ b/src/Jellyfin.Plugin.Dlna.Model/SearchCriteria.cs
@@ -1,12 +1,13 @@
 using System;
-using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System.Text;
 
 namespace Jellyfin.Plugin.Dlna.Model;
 
 /// <summary>
 /// Defines the <see cref="SearchCriteria" />.
 /// </summary>
-public partial class SearchCriteria
+public class SearchCriteria
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SearchCriteria"/> class.
@@ -18,33 +19,38 @@ public partial class SearchCriteria
 
         SearchType = SearchType.Unknown;
 
-        string[] factors = AndOrRegex().Split(search);
-        foreach (string factor in factors)
+        foreach (var (property, op, value) in ParseRelations(search))
         {
-            string[] subFactors = WhiteSpaceRegex().Split(factor.Trim().Trim('(').Trim(')').Trim(), 3);
-
-            if (subFactors.Length == 3)
+            if (string.Equals("upnp:class", property, StringComparison.OrdinalIgnoreCase)
+                && (string.Equals("=", op, StringComparison.Ordinal) || string.Equals("derivedfrom", op, StringComparison.OrdinalIgnoreCase)))
             {
-                if (string.Equals("upnp:class", subFactors[0], StringComparison.OrdinalIgnoreCase)
-                    && (string.Equals("=", subFactors[1], StringComparison.Ordinal) || string.Equals("derivedfrom", subFactors[1], StringComparison.OrdinalIgnoreCase)))
-                {
-                    if (string.Equals("\"object.item.imageItem\"", subFactors[2], StringComparison.Ordinal) || string.Equals("\"object.item.imageItem.photo\"", subFactors[2], StringComparison.OrdinalIgnoreCase))
-                    {
-                        SearchType = SearchType.Image;
-                    }
-                    else if (string.Equals("\"object.item.videoItem\"", subFactors[2], StringComparison.OrdinalIgnoreCase))
-                    {
-                        SearchType = SearchType.Video;
-                    }
-                    else if (string.Equals("\"object.container.playlistContainer\"", subFactors[2], StringComparison.OrdinalIgnoreCase))
-                    {
-                        SearchType = SearchType.Playlist;
-                    }
-                    else if (string.Equals("\"object.container.album.musicAlbum\"", subFactors[2], StringComparison.OrdinalIgnoreCase))
-                    {
-                        SearchType = SearchType.MusicAlbum;
-                    }
-                }
+                SearchType = GetSearchType(value);
+                continue;
+            }
+
+            // Only the operators that widen or match a name are of use, a negated or ordering
+            // comparison on a name can not be turned into a library query
+            if (!string.Equals("contains", op, StringComparison.OrdinalIgnoreCase)
+                && !string.Equals("=", op, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (value.Length == 0)
+            {
+                continue;
+            }
+
+            if (string.Equals("dc:title", property, StringComparison.OrdinalIgnoreCase))
+            {
+                NameContains ??= value;
+            }
+            else if (string.Equals("upnp:artist", property, StringComparison.OrdinalIgnoreCase)
+                     || string.Equals("upnp:album", property, StringComparison.OrdinalIgnoreCase)
+                     || string.Equals("upnp:albumArtist", property, StringComparison.OrdinalIgnoreCase)
+                     || string.Equals("dc:creator", property, StringComparison.OrdinalIgnoreCase))
+            {
+                SearchTerm ??= value;
             }
         }
     }
@@ -54,9 +60,146 @@ public partial class SearchCriteria
     /// </summary>
     public SearchType SearchType { get; set; }
 
-    [GeneratedRegex("\\s")]
-    private static partial Regex WhiteSpaceRegex();
+    /// <summary>
+    /// Gets or sets the title the results have to contain, if any.
+    /// </summary>
+    public string? NameContains { get; set; }
 
-    [GeneratedRegex("(and|or)", RegexOptions.IgnoreCase)]
-    private static partial Regex AndOrRegex();
+    /// <summary>
+    /// Gets or sets the term the results have to match, if any.
+    /// </summary>
+    public string? SearchTerm { get; set; }
+
+    private static SearchType GetSearchType(string upnpClass)
+    {
+        if (string.Equals("object.item.imageItem", upnpClass, StringComparison.OrdinalIgnoreCase)
+            || string.Equals("object.item.imageItem.photo", upnpClass, StringComparison.OrdinalIgnoreCase))
+        {
+            return SearchType.Image;
+        }
+
+        if (string.Equals("object.item.videoItem", upnpClass, StringComparison.OrdinalIgnoreCase))
+        {
+            return SearchType.Video;
+        }
+
+        if (string.Equals("object.item.audioItem", upnpClass, StringComparison.OrdinalIgnoreCase)
+            || string.Equals("object.item.audioItem.musicTrack", upnpClass, StringComparison.OrdinalIgnoreCase))
+        {
+            return SearchType.Audio;
+        }
+
+        if (string.Equals("object.container.playlistContainer", upnpClass, StringComparison.OrdinalIgnoreCase))
+        {
+            return SearchType.Playlist;
+        }
+
+        if (string.Equals("object.container.album.musicAlbum", upnpClass, StringComparison.OrdinalIgnoreCase))
+        {
+            return SearchType.MusicAlbum;
+        }
+
+        return SearchType.Unknown;
+    }
+
+    /// <summary>
+    /// Splits a UPnP search criteria string into its relational expressions.
+    /// </summary>
+    /// <param name="search">The search string.</param>
+    /// <returns>The property, operator and unquoted value of every relational expression.</returns>
+    /// <remarks>
+    /// Values are read as the quoted strings they are, so that a value containing a logical
+    /// operator or a parenthesis does not tear the expression it belongs to apart.
+    /// </remarks>
+    private static IEnumerable<(string Property, string Operator, string Value)> ParseRelations(string search)
+    {
+        var index = 0;
+        while (index < search.Length)
+        {
+            var property = ReadToken(search, ref index);
+            if (property.Length == 0)
+            {
+                break;
+            }
+
+            // A logical operator between two expressions, the next token starts an expression
+            if (string.Equals("and", property, StringComparison.OrdinalIgnoreCase)
+                || string.Equals("or", property, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var op = ReadToken(search, ref index);
+            if (op.Length == 0)
+            {
+                break;
+            }
+
+            var value = ReadValue(search, ref index);
+
+            yield return (property, op, value);
+        }
+    }
+
+    /// <summary>
+    /// Reads the next unquoted token, skipping over whitespace and grouping parentheses.
+    /// </summary>
+    /// <param name="search">The search string.</param>
+    /// <param name="index">The position to read from, left behind the token.</param>
+    /// <returns>The token, empty when the end of the string was reached.</returns>
+    private static string ReadToken(string search, ref int index)
+    {
+        while (index < search.Length && (char.IsWhiteSpace(search[index]) || search[index] is '(' or ')'))
+        {
+            index++;
+        }
+
+        var start = index;
+        while (index < search.Length && !char.IsWhiteSpace(search[index]) && search[index] is not ('(' or ')'))
+        {
+            index++;
+        }
+
+        return search[start..index];
+    }
+
+    /// <summary>
+    /// Reads the value of a relational expression, unescaping it when it is quoted.
+    /// </summary>
+    /// <param name="search">The search string.</param>
+    /// <param name="index">The position to read from, left behind the value.</param>
+    /// <returns>The value.</returns>
+    private static string ReadValue(string search, ref int index)
+    {
+        while (index < search.Length && char.IsWhiteSpace(search[index]))
+        {
+            index++;
+        }
+
+        if (index >= search.Length || search[index] != '"')
+        {
+            return ReadToken(search, ref index);
+        }
+
+        index++;
+        var value = new StringBuilder();
+        while (index < search.Length && search[index] != '"')
+        {
+            if (search[index] == '\\' && index + 1 < search.Length)
+            {
+                index++;
+            }
+
+            value.Append(search[index]);
+            index++;
+        }
+
+        // Step over the closing quote, if the criteria is not truncated
+        if (index < search.Length)
+        {
+            index++;
+        }
+
+        return value.ToString();
+    }
 }

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ContentDirectoryService.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ContentDirectoryService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.Dlna.Localization;
 using Jellyfin.Plugin.Dlna.Model;
 using Jellyfin.Plugin.Dlna.Service;
 using MediaBrowser.Controller.Drawing;
@@ -12,7 +13,6 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.TV;
 using MediaBrowser.Model.Dlna;
-using MediaBrowser.Model.Globalization;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.Dlna.ContentDirectory;
@@ -27,7 +27,7 @@ public class ContentDirectoryService : BaseService, IContentDirectory
     private readonly IUserDataManager _userDataManager;
     private readonly IDlnaManager _dlna;
     private readonly IUserManager _userManager;
-    private readonly ILocalizationManager _localization;
+    private readonly DlnaLocalization _localization;
     private readonly IMediaSourceManager _mediaSourceManager;
     private readonly IUserViewManager _userViewManager;
     private readonly IMediaEncoder _mediaEncoder;
@@ -43,7 +43,7 @@ public class ContentDirectoryService : BaseService, IContentDirectory
     /// <param name="userManager">The <see cref="IUserManager"/> to use in the <see cref="ContentDirectoryService"/> instance.</param>
     /// <param name="logger">The <see cref="ILogger{ContentDirectoryService}"/> to use in the <see cref="ContentDirectoryService"/> instance.</param>
     /// <param name="httpClient">The <see cref="IHttpClientFactory"/> to use in the <see cref="ContentDirectoryService"/> instance.</param>
-    /// <param name="localization">The <see cref="ILocalizationManager"/> to use in the <see cref="ContentDirectoryService"/> instance.</param>
+    /// <param name="localization">The <see cref="DlnaLocalization"/> to use in the <see cref="ContentDirectoryService"/> instance.</param>
     /// <param name="mediaSourceManager">The <see cref="IMediaSourceManager"/> to use in the <see cref="ContentDirectoryService"/> instance.</param>
     /// <param name="userViewManager">The <see cref="IUserViewManager"/> to use in the <see cref="ContentDirectoryService"/> instance.</param>
     /// <param name="mediaEncoder">The <see cref="IMediaEncoder"/> to use in the <see cref="ContentDirectoryService"/> instance.</param>
@@ -56,7 +56,7 @@ public class ContentDirectoryService : BaseService, IContentDirectory
         IUserManager userManager,
         ILogger<ContentDirectoryService> logger,
         IHttpClientFactory httpClient,
-        ILocalizationManager localization,
+        DlnaLocalization localization,
         IMediaSourceManager mediaSourceManager,
         IUserViewManager userViewManager,
         IMediaEncoder mediaEncoder,

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -399,8 +399,12 @@ public class ControlHandler : BaseControlHandler
     /// <param name="deviceId">The device id.</param>
     private void HandleXBrowseByLetter(XmlWriter xmlWriter, IReadOnlyDictionary<string, string> sparams, string deviceId)
     {
-        // TODO: Implement this method
-        HandleSearch(xmlWriter, sparams, deviceId);
+        // Devices disagree on the name of the argument carrying the letter
+        var letter = sparams.GetValueOrDefault("StartingLetter")
+                     ?? sparams.GetValueOrDefault("Letter")
+                     ?? sparams.GetValueOrDefault("StartingCharacter");
+
+        HandleSearch(xmlWriter, sparams, deviceId, string.IsNullOrWhiteSpace(letter) ? null : letter);
     }
 
     /// <summary>
@@ -409,9 +413,11 @@ public class ControlHandler : BaseControlHandler
     /// <param name="xmlWriter">The xmlWriter<see cref="XmlWriter"/>.</param>
     /// <param name="sparams">The method parameters.</param>
     /// <param name="deviceId">The deviceId<see cref="string"/>.</param>
-    private void HandleSearch(XmlWriter xmlWriter, IReadOnlyDictionary<string, string> sparams, string deviceId)
+    /// <param name="nameStartsWith">The letter the results have to start with, if any.</param>
+    private void HandleSearch(XmlWriter xmlWriter, IReadOnlyDictionary<string, string> sparams, string deviceId, string? nameStartsWith = null)
     {
-        var searchCriteria = new SearchCriteria(sparams.GetValueOrDefault("SearchCriteria", string.Empty));
+        // "*" is the criteria matching everything, and the fallback for a device that sends none
+        var searchCriteria = new SearchCriteria(sparams.GetValueOrDefault("SearchCriteria", "*"));
         var sortCriteria = new SortCriteria(sparams.GetValueOrDefault("SortCriteria", string.Empty));
         var filter = new Filter(sparams.GetValueOrDefault("Filter", "*"));
 
@@ -455,14 +461,14 @@ public class ControlHandler : BaseControlHandler
 
             var item = serverItem.Item;
 
-            childrenResult = GetSearchResultWithParts(item, _user, searchCriteria, sortCriteria, start, requestedCount);
+            childrenResult = GetSearchResultWithParts(item, _user, searchCriteria, sortCriteria, start, requestedCount, nameStartsWith);
             foreach (var i in childrenResult.Items)
             {
                 var childItem = i.Item;
 
                 if (childItem.IsDisplayedAsFolder)
                 {
-                    var childCount = GetChildrenSorted(childItem, _user, searchCriteria, sortCriteria, null, 0)
+                    var childCount = GetChildrenSorted(childItem, _user, searchCriteria, sortCriteria, null, 0, nameStartsWith)
                         .TotalRecordCount;
 
                     _didlBuilder.WriteFolderElement(writer, childItem, null, item, childCount, filter);
@@ -492,8 +498,9 @@ public class ControlHandler : BaseControlHandler
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
+    /// <param name="nameStartsWith">The letter the results have to start with, if any.</param>
     /// <returns>The <see cref="QueryResult{BaseItem}"/>.</returns>
-    private static QueryResult<BaseItem> GetChildrenSorted(BaseItem item, User? user, SearchCriteria search, SortCriteria sort, int? startIndex, int? limit)
+    private static QueryResult<BaseItem> GetChildrenSorted(BaseItem item, User? user, SearchCriteria search, SortCriteria sort, int? startIndex, int? limit, string? nameStartsWith = null)
     {
         var folder = (Folder)item;
 
@@ -531,6 +538,9 @@ public class ControlHandler : BaseControlHandler
             ExcludeItemTypes = [BaseItemKind.Book],
             IsFolder = isFolder,
             MediaTypes = mediaTypes,
+            NameContains = search.NameContains,
+            NameStartsWith = nameStartsWith,
+            SearchTerm = search.SearchTerm,
             DtoOptions = GetDtoOptions()
         });
     }
@@ -750,9 +760,10 @@ public class ControlHandler : BaseControlHandler
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
+    /// <param name="nameStartsWith">The letter the results have to start with, if any.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetSearchResultWithParts(BaseItem item, User? user, SearchCriteria search, SortCriteria sort, int? startIndex, int? limit)
-        => ApplyPaging(ExpandStackedVideos(ToResult(null, GetChildrenSorted(item, user, search, sort, null, null)).Items, user), startIndex, limit);
+    private QueryResult<ServerItem> GetSearchResultWithParts(BaseItem item, User? user, SearchCriteria search, SortCriteria sort, int? startIndex, int? limit, string? nameStartsWith = null)
+        => ApplyPaging(ExpandStackedVideos(ToResult(null, GetChildrenSorted(item, user, search, sort, null, null, nameStartsWith)).Items, user), startIndex, limit);
 
     /// <summary>
     /// Replaces every stacked (multi-part) video in a listing by one item per part, so that the

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -344,7 +344,7 @@ public class ControlHandler : BaseControlHandler
 
                 if (IsWrittenAsContainer(serverItem))
                 {
-                    var childCount = GetChildCounts([serverItem], sortCriteria)[0];
+                    var childCount = GetChildCounts([serverItem], null, sortCriteria)[0];
 
                     _didlBuilder.WriteFolderElement(writer, item, serverItem.StubType, null, childCount, filter, id);
                 }
@@ -357,12 +357,13 @@ public class ControlHandler : BaseControlHandler
             }
             else
             {
-                var childrenResult = GetUserItemsWithParts(item, serverItem.StubType, _user, sortCriteria, start, requestedCount);
+                var childrenResult = GetUserItemsWithParts(item, serverItem.StubType, _user, sortCriteria, start, requestedCount, serverItem.AncestorId);
                 totalCount = childrenResult.TotalRecordCount;
 
                 provided = childrenResult.Items.Count;
 
-                var childCounts = GetChildCounts(childrenResult.Items, sortCriteria);
+                var childAncestorIds = new Guid?[childrenResult.Items.Count];
+                var childCounts = GetChildCounts(childrenResult.Items, item, sortCriteria, childAncestorIds);
 
                 for (var index = 0; index < childrenResult.Items.Count; index++)
                 {
@@ -372,7 +373,7 @@ public class ControlHandler : BaseControlHandler
 
                     if (IsWrittenAsContainer(i))
                     {
-                        _didlBuilder.WriteFolderElement(writer, childItem, displayStubType, item, childCounts[index], filter);
+                        _didlBuilder.WriteFolderElement(writer, childItem, displayStubType, item, childCounts[index], filter, null, childAncestorIds[index]);
                     }
                     else
                     {
@@ -561,8 +562,9 @@ public class ControlHandler : BaseControlHandler
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
+    /// <param name="ancestorId">The library to scope the listing to, if any.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetUserItems(BaseItem item, StubType? stubType, User? user, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetUserItems(BaseItem item, StubType? stubType, User? user, SortCriteria sort, int? startIndex, int? limit, Guid? ancestorId = null)
     {
         if (user is not null)
         {
@@ -574,11 +576,11 @@ public class ControlHandler : BaseControlHandler
             switch (item)
             {
                 case MusicGenre:
-                    return GetMusicGenreItems(item, user, sort, startIndex, limit);
+                    return GetMusicGenreItems(item, user, sort, startIndex, limit, ancestorId);
                 case MusicArtist:
-                    return GetMusicArtistItems(item, user, sort, startIndex, limit);
+                    return GetMusicArtistItems(item, user, sort, startIndex, limit, ancestorId);
                 case Genre:
-                    return GetGenreItems(item, user, sort, startIndex, limit);
+                    return GetGenreItems(item, user, sort, startIndex, limit, ancestorId);
             }
 
             if (stubType != StubType.Folder && item is IHasCollectionType collectionFolder)
@@ -664,9 +666,11 @@ public class ControlHandler : BaseControlHandler
     /// each of them.
     /// </summary>
     /// <param name="children">The listing.</param>
+    /// <param name="parent">The <see cref="BaseItem"/> being browsed, if any.</param>
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
+    /// <param name="ancestorIds">Receives the library each entry is scoped to, if any.</param>
     /// <returns>The child counts, in the order of <paramref name="children"/>.</returns>
-    private int[] GetChildCounts(IReadOnlyList<ServerItem> children, SortCriteria sort)
+    private int[] GetChildCounts(IReadOnlyList<ServerItem> children, BaseItem? parent, SortCriteria sort, Guid?[]? ancestorIds = null)
     {
         var counts = new int[children.Count];
 
@@ -677,6 +681,16 @@ public class ControlHandler : BaseControlHandler
         for (var index = 0; index < children.Count; index++)
         {
             var child = children[index];
+
+            // A genre or artist aggregates content from every library. An id browsed into already
+            // names the library to stay within; one being listed takes it from its parent.
+            var ancestorId = child.AncestorId
+                             ?? (parent is not null && child.Item is IItemByName ? parent.Id : null);
+            if (ancestorIds is not null)
+            {
+                ancestorIds[index] = ancestorId;
+            }
+
             if (!IsWrittenAsContainer(child))
             {
                 continue;
@@ -695,7 +709,7 @@ public class ControlHandler : BaseControlHandler
             else
             {
                 // A stub container has no children of its own, its content has to be listed
-                counts[index] = GetUserItemsWithParts(child.Item, child.StubType, _user, sort, null, null)
+                counts[index] = GetUserItemsWithParts(child.Item, child.StubType, _user, sort, null, null, ancestorId)
                     .TotalRecordCount;
             }
         }
@@ -750,9 +764,10 @@ public class ControlHandler : BaseControlHandler
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
+    /// <param name="ancestorId">The library to scope the listing to, if any.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetUserItemsWithParts(BaseItem item, StubType? stubType, User? user, SortCriteria sort, int? startIndex, int? limit)
-        => ApplyPaging(ExpandStackedVideos(GetUserItems(item, stubType, user, sort, null, null).Items, user), startIndex, limit);
+    private QueryResult<ServerItem> GetUserItemsWithParts(BaseItem item, StubType? stubType, User? user, SortCriteria sort, int? startIndex, int? limit, Guid? ancestorId = null)
+        => ApplyPaging(ExpandStackedVideos(GetUserItems(item, stubType, user, sort, null, null, ancestorId).Items, user), startIndex, limit);
 
     /// <summary>
     /// Returns the search results meeting the criteria, with every stacked (multi-part) video
@@ -1326,13 +1341,15 @@ public class ControlHandler : BaseControlHandler
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
+    /// <param name="ancestorId">The library to scope the artist to, if any.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetMusicArtistItems(BaseItem item, User user, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetMusicArtistItems(BaseItem item, User user, SortCriteria sort, int? startIndex, int? limit, Guid? ancestorId)
     {
         var query = new InternalItemsQuery(user)
         {
             Recursive = true,
             ArtistIds = [item.Id],
+            AncestorIds = ancestorId.HasValue ? [ancestorId.Value] : [],
             IncludeItemTypes = [BaseItemKind.MusicAlbum],
             Limit = limit,
             StartIndex = startIndex,
@@ -1353,13 +1370,15 @@ public class ControlHandler : BaseControlHandler
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
+    /// <param name="ancestorId">The library to scope the genre to, if any.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetGenreItems(BaseItem item, User user, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetGenreItems(BaseItem item, User user, SortCriteria sort, int? startIndex, int? limit, Guid? ancestorId)
     {
         var query = new InternalItemsQuery(user)
         {
             Recursive = true,
             GenreIds = [item.Id],
+            AncestorIds = ancestorId.HasValue ? [ancestorId.Value] : [],
             IncludeItemTypes =
             [
                 BaseItemKind.Movie,
@@ -1384,13 +1403,15 @@ public class ControlHandler : BaseControlHandler
     /// <param name="sort">The <see cref="SortCriteria"/>.</param>
     /// <param name="startIndex">The start index.</param>
     /// <param name="limit">The maximum number to return.</param>
+    /// <param name="ancestorId">The library to scope the genre to, if any.</param>
     /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
-    private QueryResult<ServerItem> GetMusicGenreItems(BaseItem item, User user, SortCriteria sort, int? startIndex, int? limit)
+    private QueryResult<ServerItem> GetMusicGenreItems(BaseItem item, User user, SortCriteria sort, int? startIndex, int? limit, Guid? ancestorId)
     {
         var query = new InternalItemsQuery(user)
         {
             Recursive = true,
             GenreIds = [item.Id],
+            AncestorIds = ancestorId.HasValue ? [ancestorId.Value] : [],
             IncludeItemTypes = [BaseItemKind.MusicAlbum],
             Limit = limit,
             StartIndex = startIndex,
@@ -1512,12 +1533,22 @@ public class ControlHandler : BaseControlHandler
             stubType = parsedStubType;
         }
 
+        // An id may carry the library the client browsed in from, so that listings which would
+        // otherwise span every library stay scoped to it. Ids without it keep parsing as before.
+        Guid? ancestorId = null;
+        var ancestorIndex = id.IndexOf('_', StringComparison.Ordinal);
+        if (ancestorIndex != -1 && Guid.TryParse(id.AsSpan(ancestorIndex + 1), out var parsedAncestorId))
+        {
+            ancestorId = parsedAncestorId;
+            id = id[..ancestorIndex];
+        }
+
         if (Guid.TryParse(id, out var itemId))
         {
             var item = _libraryManager.GetItemById(itemId);
             if (item is not null)
             {
-                return new ServerItem(item, stubType);
+                return new ServerItem(item, stubType, ancestorId: ancestorId);
             }
         }
 

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -10,6 +10,7 @@ using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.Dlna.Didl;
+using Jellyfin.Plugin.Dlna.Localization;
 using Jellyfin.Plugin.Dlna.Model;
 using Jellyfin.Plugin.Dlna.Service;
 using MediaBrowser.Common.Extensions;
@@ -22,7 +23,6 @@ using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.TV;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Library;
 using MediaBrowser.Model.Querying;
 using Microsoft.Extensions.Logging;
@@ -66,7 +66,7 @@ public class ControlHandler : BaseControlHandler
     /// <param name="userDataManager">Instance of the <see cref="IUserDataManager"/> interface.</param>
     /// <param name="user">The <see cref="User"/>.</param>
     /// <param name="systemUpdateId">The system id.</param>
-    /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
+    /// <param name="localization">Instance of the <see cref="DlnaLocalization"/> class.</param>
     /// <param name="mediaSourceManager">Instance of the <see cref="IMediaSourceManager"/> interface.</param>
     /// <param name="userViewManager">Instance of the <see cref="IUserViewManager"/> interface.</param>
     /// <param name="mediaEncoder">Instance of the <see cref="IMediaEncoder"/> interface.</param>
@@ -81,7 +81,7 @@ public class ControlHandler : BaseControlHandler
         IUserDataManager userDataManager,
         User? user,
         int systemUpdateId,
-        ILocalizationManager localization,
+        DlnaLocalization localization,
         IMediaSourceManager mediaSourceManager,
         IUserViewManager userViewManager,
         IMediaEncoder mediaEncoder,

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -342,11 +342,11 @@ public class ControlHandler : BaseControlHandler
             {
                 totalCount = 1;
 
-                if (item.IsDisplayedAsFolder || serverItem.StubType.HasValue)
+                if (IsWrittenAsContainer(serverItem))
                 {
-                    var childrenResult = GetUserItemsWithParts(item, serverItem.StubType, _user, sortCriteria, start, requestedCount);
+                    var childCount = GetChildCounts([serverItem], sortCriteria)[0];
 
-                    _didlBuilder.WriteFolderElement(writer, item, serverItem.StubType, null, childrenResult.TotalRecordCount, filter, id);
+                    _didlBuilder.WriteFolderElement(writer, item, serverItem.StubType, null, childCount, filter, id);
                 }
                 else
                 {
@@ -362,17 +362,17 @@ public class ControlHandler : BaseControlHandler
 
                 provided = childrenResult.Items.Count;
 
-                foreach (var i in childrenResult.Items)
+                var childCounts = GetChildCounts(childrenResult.Items, sortCriteria);
+
+                for (var index = 0; index < childrenResult.Items.Count; index++)
                 {
+                    var i = childrenResult.Items[index];
                     var childItem = i.Item;
                     var displayStubType = i.StubType;
 
-                    if (childItem.IsDisplayedAsFolder || displayStubType.HasValue)
+                    if (IsWrittenAsContainer(i))
                     {
-                        var childCount = GetUserItemsWithParts(childItem, displayStubType, _user, sortCriteria, null, null)
-                            .TotalRecordCount;
-
-                        _didlBuilder.WriteFolderElement(writer, childItem, displayStubType, item, childCount, filter);
+                        _didlBuilder.WriteFolderElement(writer, childItem, displayStubType, item, childCounts[index], filter);
                     }
                     else
                     {
@@ -608,6 +608,122 @@ public class ControlHandler : BaseControlHandler
         var queryResult = folder.GetItems(query);
 
         return ToResult(startIndex, queryResult);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether a listing entry is written as a container.
+    /// </summary>
+    /// <param name="serverItem">The <see cref="ServerItem"/>.</param>
+    /// <returns><c>true</c> if the entry is written as a container.</returns>
+    private static bool IsWrittenAsContainer(ServerItem serverItem)
+        => serverItem.Item.IsDisplayedAsFolder || serverItem.StubType.HasValue;
+
+    /// <summary>
+    /// Gets a value indicating whether the children of a listing entry are the folder's own
+    /// children, so that they can be counted without listing them.
+    /// </summary>
+    /// <param name="serverItem">The <see cref="ServerItem"/>.</param>
+    /// <returns><c>true</c> if the entry is a folder listing its own children.</returns>
+    private bool ListsOwnChildren(ServerItem serverItem)
+    {
+        if (serverItem.Item is not Folder || serverItem.StubType is not (null or StubType.Folder))
+        {
+            return false;
+        }
+
+        // Mirrors the dispatching in GetUserItems: a collection folder is listed as a set of stub
+        // containers rather than as its own children, unless it is browsed as a plain folder
+        return serverItem.StubType == StubType.Folder
+            || _user is null
+            || serverItem.Item is not IHasCollectionType
+            {
+                CollectionType: CollectionType.music
+                    or CollectionType.movies
+                    or CollectionType.tvshows
+                    or CollectionType.folders
+                    or CollectionType.livetv
+            };
+    }
+
+    /// <summary>
+    /// Determines the child count of every container in a listing, without listing the content of
+    /// each of them.
+    /// </summary>
+    /// <param name="children">The listing.</param>
+    /// <param name="sort">The <see cref="SortCriteria"/>.</param>
+    /// <returns>The child counts, in the order of <paramref name="children"/>.</returns>
+    private int[] GetChildCounts(IReadOnlyList<ServerItem> children, SortCriteria sort)
+    {
+        var counts = new int[children.Count];
+
+        // Folders are counted in a single batched query instead of one query per entry
+        List<Guid> folderIds = [];
+        List<int> folderIndexes = [];
+
+        for (var index = 0; index < children.Count; index++)
+        {
+            var child = children[index];
+            if (!IsWrittenAsContainer(child))
+            {
+                continue;
+            }
+
+            var itemByNameCount = GetItemByNameChildCount(child.Item);
+            if (itemByNameCount.HasValue)
+            {
+                counts[index] = itemByNameCount.Value;
+            }
+            else if (ListsOwnChildren(child))
+            {
+                folderIds.Add(child.Item.Id);
+                folderIndexes.Add(index);
+            }
+            else
+            {
+                // A stub container has no children of its own, its content has to be listed
+                counts[index] = GetUserItemsWithParts(child.Item, child.StubType, _user, sort, null, null)
+                    .TotalRecordCount;
+            }
+        }
+
+        if (folderIds.Count > 0)
+        {
+            var folderCounts = _libraryManager.GetChildCountBatch(folderIds, _user?.Id);
+            for (var i = 0; i < folderIds.Count; i++)
+            {
+                counts[folderIndexes[i]] = folderCounts.GetValueOrDefault(folderIds[i]);
+            }
+        }
+
+        return counts;
+    }
+
+    /// <summary>
+    /// Gets the child count of a "by name" container using an optimized count query, instead of
+    /// listing every item below it.
+    /// </summary>
+    /// <param name="item">The <see cref="BaseItem"/>.</param>
+    /// <returns>The child count, or <c>null</c> if the item is not a "by name" container.</returns>
+    private int? GetItemByNameChildCount(BaseItem item)
+    {
+        // The counted kinds have to match what GetUserItems lists for the container
+        switch (item)
+        {
+            case MusicGenre:
+                return _libraryManager
+                    .GetItemCountsForNameItem(BaseItemKind.MusicGenre, item.Id, [BaseItemKind.MusicAlbum], _user)
+                    .AlbumCount;
+            case MusicArtist:
+                return _libraryManager
+                    .GetItemCountsForNameItem(BaseItemKind.MusicArtist, item.Id, [BaseItemKind.MusicAlbum], _user)
+                    .AlbumCount;
+            case Genre:
+                var counts = _libraryManager
+                    .GetItemCountsForNameItem(BaseItemKind.Genre, item.Id, [BaseItemKind.Movie, BaseItemKind.Series], _user);
+                return counts.MovieCount + counts.SeriesCount;
+            default:
+                return null;
+        }
     }
 
     /// <summary>

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -40,6 +40,7 @@ public class ControlHandler : BaseControlHandler
     private const string NsDidl = "urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/";
     private const string NsDlna = "urn:schemas-dlna-org:metadata-1-0/";
     private const string NsUpnp = "urn:schemas-upnp-org:metadata-1-0/upnp/";
+    private const int MaxPageSize = 200;
 
     private readonly ILibraryManager _libraryManager;
     private readonly IUserDataManager _userDataManager;
@@ -300,14 +301,12 @@ public class ControlHandler : BaseControlHandler
 
         var provided = 0;
 
-        // Default to null instead of 0
-        // Upnp inspector sends 0 as requestedCount when it wants everything
-        int? requestedCount = null;
+        int? requestedCount = MaxPageSize;
         int? start = 0;
 
         if (sparams.ContainsKey("RequestedCount") && int.TryParse(sparams["RequestedCount"], out var requestedVal) && requestedVal > 0)
         {
-            requestedCount = requestedVal;
+            requestedCount = Math.Min(requestedVal, MaxPageSize);
         }
 
         if (sparams.ContainsKey("StartingIndex") && int.TryParse(sparams["StartingIndex"], out var startVal) && startVal > 0)
@@ -424,14 +423,12 @@ public class ControlHandler : BaseControlHandler
 
         // sort example: dc:title, dc:date
 
-        // Default to null instead of 0
-        // Upnp inspector sends 0 as requestedCount when it wants everything
-        int? requestedCount = null;
+        int? requestedCount = MaxPageSize;
         int? start = 0;
 
         if (sparams.ContainsKey("RequestedCount") && int.TryParse(sparams["RequestedCount"], out var requestedVal) && requestedVal > 0)
         {
-            requestedCount = requestedVal;
+            requestedCount = Math.Min(requestedVal, MaxPageSize);
         }
 
         if (sparams.ContainsKey("StartingIndex") && int.TryParse(sparams["StartingIndex"], out var startVal) && startVal > 0)

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ControlHandler.cs
@@ -23,6 +23,7 @@ using MediaBrowser.Controller.TV;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.Library;
 using MediaBrowser.Model.Querying;
 using Microsoft.Extensions.Logging;
 using DeviceProfile = MediaBrowser.Model.Dlna.DeviceProfile;
@@ -568,6 +569,11 @@ public class ControlHandler : BaseControlHandler
     {
         if (user is not null)
         {
+            if (item is UserRootFolder)
+            {
+                return GetUserViews(user, startIndex, limit);
+            }
+
             switch (item)
             {
                 case MusicGenre:
@@ -636,7 +642,8 @@ public class ControlHandler : BaseControlHandler
     /// <returns><c>true</c> if the entry is a folder listing its own children.</returns>
     private bool ListsOwnChildren(ServerItem serverItem)
     {
-        if (serverItem.Item is not Folder || serverItem.StubType is not (null or StubType.Folder))
+        // A user view holds no children of its own, it delegates to the libraries behind it
+        if (serverItem.Item is not Folder || serverItem.Item is UserView || serverItem.StubType is not (null or StubType.Folder))
         {
             return false;
         }
@@ -992,6 +999,24 @@ public class ControlHandler : BaseControlHandler
             startIndex,
             array.Length,
             array);
+    }
+
+    /// <summary>
+    /// Returns the user views, which is the top level listing every other client is served.
+    /// </summary>
+    /// <param name="user">The <see cref="User"/>.</param>
+    /// <param name="startIndex">The start index.</param>
+    /// <param name="limit">The maximum number to return.</param>
+    /// <returns>The <see cref="QueryResult{ServerItem}"/>.</returns>
+    /// <remarks>
+    /// Listing the raw children of the user root folder instead would skip library grouping, the
+    /// hidden library and display order preferences, and the synthetic views such as "Folders".
+    /// </remarks>
+    private QueryResult<ServerItem> GetUserViews(User user, int? startIndex, int? limit)
+    {
+        var views = _userViewManager.GetUserViews(new UserViewQuery { User = user });
+
+        return ApplyPaging([.. views.Select(i => new ServerItem(i, null))], startIndex, limit);
     }
 
     /// <summary>

--- a/src/Jellyfin.Plugin.Dlna/ContentDirectory/ServerItem.cs
+++ b/src/Jellyfin.Plugin.Dlna/ContentDirectory/ServerItem.cs
@@ -1,3 +1,4 @@
+using System;
 using MediaBrowser.Controller.Entities;
 
 namespace Jellyfin.Plugin.Dlna.ContentDirectory;
@@ -13,10 +14,12 @@ internal sealed class ServerItem
     /// <param name="item">The <see cref="BaseItem"/>.</param>
     /// <param name="stubType">The stub type.</param>
     /// <param name="partNumber">The one based part number of a stacked (multi-part) video.</param>
-    public ServerItem(BaseItem item, StubType? stubType, int? partNumber = null)
+    /// <param name="ancestorId">The library the client browsed in from.</param>
+    public ServerItem(BaseItem item, StubType? stubType, int? partNumber = null, Guid? ancestorId = null)
     {
         Item = item;
         PartNumber = partNumber;
+        AncestorId = ancestorId;
 
         if (stubType.HasValue)
         {
@@ -42,4 +45,10 @@ internal sealed class ServerItem
     /// Gets the one based part number when the item is one part of a stacked (multi-part) video.
     /// </summary>
     public int? PartNumber { get; }
+
+    /// <summary>
+    /// Gets the library the client browsed in from, for items such as genres and artists whose
+    /// content otherwise spans every library.
+    /// </summary>
+    public Guid? AncestorId { get; }
 }

--- a/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
@@ -8,6 +8,7 @@ using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.Dlna.ContentDirectory;
 using Jellyfin.Plugin.Dlna.Extensions;
+using Jellyfin.Plugin.Dlna.Localization;
 using Jellyfin.Plugin.Dlna.Model;
 using MediaBrowser.Controller.Channels;
 using MediaBrowser.Controller.Drawing;
@@ -19,7 +20,6 @@ using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Playlists;
 using MediaBrowser.Model.Drawing;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Net;
 using Microsoft.Extensions.Logging;
 using Episode = MediaBrowser.Controller.Entities.TV.Episode;
@@ -53,7 +53,7 @@ public class DidlBuilder
     private readonly string? _accessToken;
     private readonly User? _user;
     private readonly IUserDataManager _userDataManager;
-    private readonly ILocalizationManager _localization;
+    private readonly DlnaLocalization _localization;
     private readonly IMediaSourceManager _mediaSourceManager;
     private readonly ILogger _logger;
     private readonly IMediaEncoder _mediaEncoder;
@@ -68,7 +68,7 @@ public class DidlBuilder
     /// <param name="serverAddress">The server address.</param>
     /// <param name="accessToken">The access token.</param>
     /// <param name="userDataManager">Instance of the <see cref="IUserDataManager"/> interface.</param>
-    /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
+    /// <param name="localization">Instance of the <see cref="DlnaLocalization"/> class.</param>
     /// <param name="mediaSourceManager">Instance of the <see cref="IMediaSourceManager"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
     /// <param name="mediaEncoder">Instance of the <see cref="IMediaEncoder"/> interface.</param>
@@ -80,7 +80,7 @@ public class DidlBuilder
         string serverAddress,
         string? accessToken,
         IUserDataManager userDataManager,
-        ILocalizationManager localization,
+        DlnaLocalization localization,
         IMediaSourceManager mediaSourceManager,
         ILogger logger,
         IMediaEncoder mediaEncoder,

--- a/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
@@ -715,7 +715,8 @@ public class DidlBuilder
     /// <param name="childCount">The child count.</param>
     /// <param name="filter">The <see cref="Filter"/>.</param>
     /// <param name="requestedId">The request id.</param>
-    public void WriteFolderElement(XmlWriter writer, BaseItem folder, StubType? stubType, BaseItem? context, int childCount, Filter filter, string? requestedId = null)
+    /// <param name="ancestorId">The library to scope the folder to, if any.</param>
+    public void WriteFolderElement(XmlWriter writer, BaseItem folder, StubType? stubType, BaseItem? context, int childCount, Filter filter, string? requestedId = null, Guid? ancestorId = null)
     {
         writer.WriteStartElement(string.Empty, "container", NsDidl);
 
@@ -723,7 +724,7 @@ public class DidlBuilder
         writer.WriteAttributeString("searchable", "1");
         writer.WriteAttributeString("childCount", childCount.ToString(CultureInfo.InvariantCulture));
 
-        var clientId = GetClientId(folder, stubType);
+        var clientId = GetClientId(folder, stubType, ancestorId);
 
         if (string.Equals(requestedId, "0", StringComparison.Ordinal))
         {
@@ -1285,10 +1286,11 @@ public class DidlBuilder
     /// </summary>
     /// <param name="item">The <see cref="BaseItem"/>.</param>
     /// <param name="stubType">Current <see cref="StubType"/>.</param>
+    /// <param name="ancestorId">The library to scope the item to, if any.</param>
     /// <returns>The client id.</returns>
-    public static string GetClientId(BaseItem item, StubType? stubType)
+    public static string GetClientId(BaseItem item, StubType? stubType, Guid? ancestorId = null)
     {
-        return GetClientId(item.Id, stubType);
+        return GetClientId(item.Id, stubType, ancestorId);
     }
 
     /// <summary>
@@ -1296,14 +1298,20 @@ public class DidlBuilder
     /// </summary>
     /// <param name="idValue">The <see cref="Guid"/>.</param>
     /// <param name="stubType">Current <see cref="StubType"/>.</param>
+    /// <param name="ancestorId">The library to scope the item to, if any.</param>
     /// <returns>The client id.</returns>
-    public static string GetClientId(Guid idValue, StubType? stubType)
+    public static string GetClientId(Guid idValue, StubType? stubType, Guid? ancestorId = null)
     {
         var id = idValue.ToString("N", CultureInfo.InvariantCulture);
 
         if (stubType.HasValue)
         {
             id = stubType.Value.ToString().ToLowerInvariant() + "_" + id;
+        }
+
+        if (ancestorId.HasValue)
+        {
+            id += "_" + ancestorId.Value.ToString("N", CultureInfo.InvariantCulture);
         }
 
         return id;

--- a/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
@@ -239,7 +239,7 @@ public class DidlBuilder
             }
         }
 
-        AddCover(item, null, writer);
+        AddCover(item, null, writer, false);
         writer.WriteFullEndElement();
     }
 
@@ -754,7 +754,7 @@ public class DidlBuilder
 
         AddGeneralProperties(folder, stubType, context, writer, filter);
 
-        AddCover(folder, stubType, writer);
+        AddCover(folder, stubType, writer, true);
 
         writer.WriteFullEndElement();
     }
@@ -1052,7 +1052,7 @@ public class DidlBuilder
         }
     }
 
-    private void AddCover(BaseItem item, StubType? stubType, XmlWriter writer)
+    private void AddCover(BaseItem item, StubType? stubType, XmlWriter writer, bool isContainer)
     {
         ImageDownloadInfo? imageInfo = GetImageInfo(item);
 
@@ -1084,6 +1084,11 @@ public class DidlBuilder
             _profile.MaxIconHeight ?? 48,
             "jpg");
         writer.WriteElementString("upnp", "icon", NsUpnp, iconUrlInfo.Url);
+
+        if (isContainer)
+        {
+            return;
+        }
 
         if (!_profile.EnableAlbumArtInDidl)
         {

--- a/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
@@ -962,7 +962,8 @@ public class DidlBuilder
             new InternalPeopleQuery
             {
                 ItemId = item.Id,
-                Limit = 6
+                Limit = 6,
+                EnableTotalRecordCount = false
             });
 
         foreach (var actor in people)

--- a/src/Jellyfin.Plugin.Dlna/DlnaServiceRegistrator.cs
+++ b/src/Jellyfin.Plugin.Dlna/DlnaServiceRegistrator.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text;
 using Jellyfin.Plugin.Dlna.ConnectionManager;
 using Jellyfin.Plugin.Dlna.ContentDirectory;
+using Jellyfin.Plugin.Dlna.Localization;
 using Jellyfin.Plugin.Dlna.Main;
 using Jellyfin.Plugin.Dlna.MediaReceiverRegistrar;
 using Jellyfin.Plugin.Dlna.Model;
@@ -47,6 +48,7 @@ public class DlnaServiceRegistrator : IPluginServiceRegistrator
                 RequestHeaderEncodingSelector = (_, _) => Encoding.UTF8
             });
 
+        serviceCollection.AddSingleton<DlnaLocalization>();
         serviceCollection.AddSingleton<IDlnaManager, DlnaManager>();
         serviceCollection.AddSingleton<IDeviceDiscovery, DeviceDiscovery>();
         serviceCollection.AddSingleton<IContentDirectory, ContentDirectoryService>();

--- a/src/Jellyfin.Plugin.Dlna/Jellyfin.Plugin.Dlna.csproj
+++ b/src/Jellyfin.Plugin.Dlna/Jellyfin.Plugin.Dlna.csproj
@@ -23,6 +23,7 @@
       <EmbeddedResource Include="Configuration\config.js" />
       <EmbeddedResource Include="Images\*.jpg" />
       <EmbeddedResource Include="Images\*.png" />
+      <EmbeddedResource Include="Localization\*.json" />
       <EmbeddedResource Include="Profiles\Xml\*.xml" />
     </ItemGroup>
 

--- a/src/Jellyfin.Plugin.Dlna/Localization/DlnaLocalization.cs
+++ b/src/Jellyfin.Plugin.Dlna/Localization/DlnaLocalization.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Model.Globalization;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Dlna.Localization;
+
+/// <summary>
+/// Resolves the display names the plugin shows to DLNA clients.
+/// </summary>
+public class DlnaLocalization
+{
+    private const string DefaultCulture = "en-US";
+    private const string ResourcePrefix = "Jellyfin.Plugin.Dlna.Localization.";
+
+    private static readonly Assembly _assembly = typeof(DlnaLocalization).Assembly;
+
+    private readonly IServerConfigurationManager _config;
+    private readonly ILocalizationManager _localization;
+    private readonly ILogger<DlnaLocalization> _logger;
+    private readonly ConcurrentDictionary<string, IReadOnlyDictionary<string, string>> _dictionaries = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DlnaLocalization"/> class.
+    /// </summary>
+    /// <param name="config">Instance of the <see cref="IServerConfigurationManager"/> interface.</param>
+    /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
+    /// <param name="logger">Instance of the <see cref="ILogger{DlnaLocalization}"/> interface.</param>
+    public DlnaLocalization(IServerConfigurationManager config, ILocalizationManager localization, ILogger<DlnaLocalization> logger)
+    {
+        _config = config;
+        _localization = localization;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets the localized string for a key, in the culture the server is configured to use.
+    /// </summary>
+    /// <param name="phrase">The key to translate.</param>
+    /// <returns>The translation, or the key itself when nothing carries it.</returns>
+    public string GetLocalizedString(string phrase)
+    {
+        var culture = _config.Configuration.UICulture;
+        if (string.IsNullOrEmpty(culture))
+        {
+            culture = DefaultCulture;
+        }
+
+        if (TryGetShippedString(culture, phrase, out var value))
+        {
+            return value;
+        }
+
+        // A regional culture falls back to the plain language the plugin ships, so that "de-DE"
+        // is served by "de".
+        var separator = culture.IndexOf('-', StringComparison.Ordinal);
+        if (separator > 0 && TryGetShippedString(culture[..separator], phrase, out value))
+        {
+            return value;
+        }
+
+        if (!string.Equals(culture, DefaultCulture, StringComparison.OrdinalIgnoreCase)
+            && TryGetShippedString(DefaultCulture, phrase, out value))
+        {
+            return value;
+        }
+
+        // Everything the plugin does not ship is a string Jellyfin itself translates.
+        return _localization.GetLocalizedString(phrase);
+    }
+
+    private bool TryGetShippedString(string culture, string phrase, out string value)
+    {
+        var dictionary = _dictionaries.GetOrAdd(culture, LoadCulture);
+
+        return dictionary.TryGetValue(phrase, out value!);
+    }
+
+    private IReadOnlyDictionary<string, string> LoadCulture(string culture)
+    {
+        var resource = ResourcePrefix + culture + ".json";
+
+        try
+        {
+            using var stream = _assembly.GetManifestResourceStream(resource);
+            if (stream is null)
+            {
+                // Not every culture is translated, which the caller handles by falling back.
+                return new Dictionary<string, string>();
+            }
+
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(stream)
+                   ?? new Dictionary<string, string>();
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Error parsing bundled translations for {Culture}", culture);
+
+            return new Dictionary<string, string>();
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/cs.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/cs.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Alba",
+    "HeaderAlbumArtists": "Umělci alba",
+    "HeaderFavoriteAlbums": "Oblíbená alba",
+    "HeaderFavoriteArtists": "Oblíbení umělci",
+    "HeaderFavoriteSongs": "Oblíbené skladby",
+    "Playlists": "Seznamy skladeb",
+    "Songs": "Skladby"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/da.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/da.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Album",
+    "HeaderAlbumArtists": "Albumkunstnere",
+    "HeaderFavoriteAlbums": "Yndlingsalbum",
+    "HeaderFavoriteArtists": "Yndlingskunstnere",
+    "HeaderFavoriteSongs": "Yndlingssange",
+    "Playlists": "Afspilningslister",
+    "Songs": "Sange"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/de.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/de.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Alben",
+    "HeaderAlbumArtists": "Album-Künstler",
+    "HeaderFavoriteAlbums": "Lieblingsalben",
+    "HeaderFavoriteArtists": "Lieblingskünstler",
+    "HeaderFavoriteSongs": "Lieblingstitel",
+    "Playlists": "Wiedergabelisten",
+    "Songs": "Titel"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/en-US.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/en-US.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Albums",
+    "HeaderAlbumArtists": "Album Artists",
+    "HeaderFavoriteAlbums": "Favorite Albums",
+    "HeaderFavoriteArtists": "Favorite Artists",
+    "HeaderFavoriteSongs": "Favorite Songs",
+    "Playlists": "Playlists",
+    "Songs": "Songs"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/es.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/es.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Álbumes",
+    "HeaderAlbumArtists": "Artistas del álbum",
+    "HeaderFavoriteAlbums": "Álbumes favoritos",
+    "HeaderFavoriteArtists": "Artistas favoritos",
+    "HeaderFavoriteSongs": "Canciones favoritas",
+    "Playlists": "Listas de reproducción",
+    "Songs": "Canciones"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/fr.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/fr.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Albums",
+    "HeaderAlbumArtists": "Artistes d'album",
+    "HeaderFavoriteAlbums": "Albums favoris",
+    "HeaderFavoriteArtists": "Artistes favoris",
+    "HeaderFavoriteSongs": "Morceaux favoris",
+    "Playlists": "Listes de lecture",
+    "Songs": "Morceaux"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/it.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/it.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Album",
+    "HeaderAlbumArtists": "Artisti dell'album",
+    "HeaderFavoriteAlbums": "Album preferiti",
+    "HeaderFavoriteArtists": "Artisti preferiti",
+    "HeaderFavoriteSongs": "Brani preferiti",
+    "Playlists": "Playlist",
+    "Songs": "Brani"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/ja.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/ja.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "アルバム",
+    "HeaderAlbumArtists": "アルバムアーティスト",
+    "HeaderFavoriteAlbums": "お気に入りのアルバム",
+    "HeaderFavoriteArtists": "お気に入りのアーティスト",
+    "HeaderFavoriteSongs": "お気に入りの曲",
+    "Playlists": "プレイリスト",
+    "Songs": "曲"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/nl.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/nl.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Albums",
+    "HeaderAlbumArtists": "Albumartiesten",
+    "HeaderFavoriteAlbums": "Favoriete albums",
+    "HeaderFavoriteArtists": "Favoriete artiesten",
+    "HeaderFavoriteSongs": "Favoriete nummers",
+    "Playlists": "Afspeellijsten",
+    "Songs": "Nummers"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/pl.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/pl.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Albumy",
+    "HeaderAlbumArtists": "Wykonawcy albumu",
+    "HeaderFavoriteAlbums": "Ulubione albumy",
+    "HeaderFavoriteArtists": "Ulubieni wykonawcy",
+    "HeaderFavoriteSongs": "Ulubione utwory",
+    "Playlists": "Listy odtwarzania",
+    "Songs": "Utwory"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/pt-BR.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/pt-BR.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Álbuns",
+    "HeaderAlbumArtists": "Artistas do álbum",
+    "HeaderFavoriteAlbums": "Álbuns favoritos",
+    "HeaderFavoriteArtists": "Artistas favoritos",
+    "HeaderFavoriteSongs": "Músicas favoritas",
+    "Playlists": "Listas de reprodução",
+    "Songs": "Músicas"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/ru.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/ru.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Альбомы",
+    "HeaderAlbumArtists": "Исполнители альбома",
+    "HeaderFavoriteAlbums": "Избранные альбомы",
+    "HeaderFavoriteArtists": "Избранные исполнители",
+    "HeaderFavoriteSongs": "Избранные композиции",
+    "Playlists": "Плейлисты",
+    "Songs": "Композиции"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/sv.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/sv.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "Album",
+    "HeaderAlbumArtists": "Albumartister",
+    "HeaderFavoriteAlbums": "Favoritalbum",
+    "HeaderFavoriteArtists": "Favoritartister",
+    "HeaderFavoriteSongs": "Favoritlåtar",
+    "Playlists": "Spellistor",
+    "Songs": "Låtar"
+}

--- a/src/Jellyfin.Plugin.Dlna/Localization/zh-CN.json
+++ b/src/Jellyfin.Plugin.Dlna/Localization/zh-CN.json
@@ -1,0 +1,9 @@
+{
+    "Albums": "专辑",
+    "HeaderAlbumArtists": "专辑艺术家",
+    "HeaderFavoriteAlbums": "收藏的专辑",
+    "HeaderFavoriteArtists": "收藏的艺术家",
+    "HeaderFavoriteSongs": "收藏的歌曲",
+    "Playlists": "播放列表",
+    "Songs": "歌曲"
+}

--- a/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
+++ b/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
@@ -185,7 +185,7 @@ public sealed class DlnaHost : IHostedService, IDisposable
             .Replace(":1", string.Empty, StringComparison.OrdinalIgnoreCase)
             .Split(':');
 
-        device.DeviceTypeNamespace = serviceParts[0].Replace('.', '-');
+        device.DeviceTypeNamespace = serviceParts[0];
         device.DeviceClass = serviceParts[1];
         device.DeviceType = serviceParts[2];
     }
@@ -297,7 +297,9 @@ public sealed class DlnaHost : IHostedService, IDisposable
             {
                 "urn:schemas-upnp-org:service:ContentDirectory:1",
                 "urn:schemas-upnp-org:service:ConnectionManager:1",
-                // "urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1"
+
+                // Windows looks for this service to treat the server as a media source
+                "urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1"
             };
 
             foreach (var subDevice in embeddedDevices)

--- a/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
+++ b/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.Dlna.Configuration;
+using Jellyfin.Plugin.Dlna.Localization;
 using Jellyfin.Plugin.Dlna.Model;
 using Jellyfin.Plugin.Dlna.PlayTo;
 using Jellyfin.Plugin.Dlna.Ssdp;
@@ -19,7 +20,6 @@ using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Session;
-using MediaBrowser.Model.Globalization;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Rssdp;
@@ -42,7 +42,7 @@ public sealed class DlnaHost : IHostedService, IDisposable
     private readonly IDlnaManager _dlnaManager;
     private readonly IImageProcessor _imageProcessor;
     private readonly IUserDataManager _userDataManager;
-    private readonly ILocalizationManager _localization;
+    private readonly DlnaLocalization _localization;
     private readonly IMediaSourceManager _mediaSourceManager;
     private readonly IMediaEncoder _mediaEncoder;
     private readonly IDeviceDiscovery _deviceDiscovery;
@@ -67,7 +67,7 @@ public sealed class DlnaHost : IHostedService, IDisposable
     /// <param name="dlnaManager">The <see cref="IDlnaManager"/>.</param>
     /// <param name="imageProcessor">The <see cref="IImageProcessor"/>.</param>
     /// <param name="userDataManager">The <see cref="IUserDataManager"/>.</param>
-    /// <param name="localizationManager">The <see cref="ILocalizationManager"/>.</param>
+    /// <param name="localizationManager">The <see cref="DlnaLocalization"/>.</param>
     /// <param name="mediaSourceManager">The <see cref="IMediaSourceManager"/>.</param>
     /// <param name="deviceDiscovery">The <see cref="IDeviceDiscovery"/>.</param>
     /// <param name="mediaEncoder">The <see cref="IMediaEncoder"/>.</param>
@@ -84,7 +84,7 @@ public sealed class DlnaHost : IHostedService, IDisposable
         IDlnaManager dlnaManager,
         IImageProcessor imageProcessor,
         IUserDataManager userDataManager,
-        ILocalizationManager localizationManager,
+        DlnaLocalization localizationManager,
         IMediaSourceManager mediaSourceManager,
         IDeviceDiscovery deviceDiscovery,
         IMediaEncoder mediaEncoder,

--- a/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
+++ b/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
@@ -127,11 +127,24 @@ public sealed class DlnaHost : IHostedService, IDisposable
     }
 
     /// <inheritdoc />
-    public Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
-        Stop();
+        _config.NamedConfigurationUpdated -= OnNamedConfigurationUpdated;
 
-        return Task.CompletedTask;
+        var publisher = _publisher;
+        if (publisher is not null)
+        {
+            try
+            {
+                await publisher.StopAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error announcing the shutdown of the DLNA server");
+            }
+        }
+
+        Stop();
     }
 
     /// <inheritdoc />

--- a/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
+++ b/src/Jellyfin.Plugin.Dlna/Main/DlnaHost.cs
@@ -246,7 +246,6 @@ public sealed class DlnaHost : IHostedService, IDisposable
         // IPv6 is currently unsupported
         var validInterfaces = _networkManager.GetInternalBindAddresses()
             .Where(x => x.Address is not null)
-            .Where(x => x.AddressFamily != AddressFamily.InterNetworkV6)
             .Where(x => x.AddressFamily == AddressFamily.InterNetwork)
             .Where(x => x.SupportsMulticast)
             .Where(x => !x.Address.Equals(IPAddress.Loopback))
@@ -256,17 +255,25 @@ public sealed class DlnaHost : IHostedService, IDisposable
 
         if (validInterfaces.Count == 0)
         {
-            // No interfaces returned, fall back to loopback
-            validInterfaces = _networkManager.GetLoopbacks().ToList();
+            // No interfaces returned, fall back to loopback.
+            // As IPv6 is unsupported, the IPv6 loopback is of no use here either.
+            validInterfaces = _networkManager.GetLoopbacks()
+                .Where(x => x.AddressFamily == AddressFamily.InterNetwork)
+                .ToList();
+
+            if (validInterfaces.Count == 0)
+            {
+                _logger.LogWarning("Found no usable IPv4 interface, not registering any server endpoint");
+                return;
+            }
         }
 
         foreach (var intf in validInterfaces)
         {
             var fullService = "urn:schemas-upnp-org:device:MediaServer:1";
 
-            var uri = new UriBuilder(intf.Address + descriptorUri);
-            uri.Scheme = "http://";
-            uri.Port = httpBindPort;
+            // Build the URI from its parts, so that the host is escaped correctly
+            var uri = new UriBuilder("http", intf.Address.ToString(), httpBindPort, descriptorUri);
 
             _logger.LogInformation("Registering publisher for {ResourceName} on {DeviceAddress} with uri {FullUri}", fullService, intf.Address, uri);
 

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
@@ -1135,6 +1135,18 @@ public class Device : IDisposable
     }
 
     /// <summary>
+    /// Gets the base URL a device is reachable at from the location of its device description.
+    /// </summary>
+    /// <param name="descriptionLocation">The location of the device description.</param>
+    /// <returns>The base URL.</returns>
+    internal static string GetBaseUrl(Uri descriptionLocation)
+    {
+        ArgumentNullException.ThrowIfNull(descriptionLocation);
+
+        return string.Format(CultureInfo.InvariantCulture, "http://{0}:{1}", descriptionLocation.Host, descriptionLocation.Port);
+    }
+
+    /// <summary>
     /// Creates uPNP device.
     /// </summary>
     /// <param name="url">The <see cref="Uri"/>.</param>

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToManager.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToManager.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Events;
+using Jellyfin.Plugin.Dlna.Localization;
 using Jellyfin.Plugin.Dlna.Model;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller;
@@ -12,7 +13,6 @@ using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Session;
-using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Session;
 using Microsoft.Extensions.Logging;
 using IDlnaManager = Jellyfin.Plugin.Dlna.Model.IDlnaManager;
@@ -33,7 +33,7 @@ public sealed class PlayToManager : IDisposable
     private readonly IImageProcessor _imageProcessor;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IUserDataManager _userDataManager;
-    private readonly ILocalizationManager _localization;
+    private readonly DlnaLocalization _localization;
     private readonly IDeviceDiscovery _deviceDiscovery;
     private readonly IMediaSourceManager _mediaSourceManager;
     private readonly IMediaEncoder _mediaEncoder;
@@ -54,7 +54,7 @@ public sealed class PlayToManager : IDisposable
     /// <param name="deviceDiscovery">Instance of the <see cref="IDeviceDiscovery"/> interface.</param>
     /// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
     /// <param name="userDataManager">Instance of the <see cref="IUserDataManager"/> interface.</param>
-    /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
+    /// <param name="localization">Instance of the <see cref="DlnaLocalization"/> class.</param>
     /// <param name="mediaSourceManager">Instance of the <see cref="IMediaSourceManager"/> interface.</param>
     /// <param name="mediaEncoder">Instance of the <see cref="IMediaEncoder"/> interface.</param>
     public PlayToManager(
@@ -68,7 +68,7 @@ public sealed class PlayToManager : IDisposable
         IDeviceDiscovery deviceDiscovery,
         IHttpClientFactory httpClientFactory,
         IUserDataManager userDataManager,
-        ILocalizationManager localization,
+        DlnaLocalization localization,
         IMediaSourceManager mediaSourceManager,
         IMediaEncoder mediaEncoder)
     {

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToManager.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToManager.cs
@@ -132,9 +132,24 @@ public sealed class PlayToManager : IDisposable
                 return;
             }
 
-            if (_sessionManager.Sessions.Any(i => usn.Contains(i.DeviceId, StringComparison.OrdinalIgnoreCase)))
+            var existingSession = _sessionManager.Sessions.FirstOrDefault(
+                i => !string.IsNullOrEmpty(i.DeviceId) && usn.Contains(i.DeviceId, StringComparison.OrdinalIgnoreCase));
+
+            if (existingSession is not null)
             {
-                return;
+                if (!HasMoved(existingSession, info.Location))
+                {
+                    return;
+                }
+
+                // The renderer is reachable at another address than the one its controller was
+                // built from, so that controller can only talk to a dead endpoint from now on
+                _logger.LogInformation(
+                    "Renderer {Name} moved to {Location}, recreating its session",
+                    existingSession.DeviceName,
+                    info.Location);
+
+                await _sessionManager.ReportSessionEnded(existingSession.Id).ConfigureAwait(false);
             }
 
             await AddDevice(info, cancellationToken).ConfigureAwait(false);
@@ -150,6 +165,29 @@ public sealed class PlayToManager : IDisposable
         {
             _sessionLock.Release();
         }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether a renderer announced itself at another address than the one
+    /// the controller of its existing session was built from.
+    /// </summary>
+    /// <param name="session">The existing <see cref="SessionInfo"/>.</param>
+    /// <param name="location">The announced location of the device description.</param>
+    /// <returns><c>true</c> when the announced address differs from the one in use.</returns>
+    private static bool HasMoved(SessionInfo session, Uri? location)
+    {
+        if (location is null)
+        {
+            return false;
+        }
+
+        var controller = session.SessionControllers.OfType<PlayToSession>().FirstOrDefault();
+        if (controller is null)
+        {
+            return false;
+        }
+
+        return !string.Equals(controller.DeviceBaseUrl, Device.GetBaseUrl(location), StringComparison.OrdinalIgnoreCase);
     }
 
     internal static string GetUuid(string usn)

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
@@ -10,6 +10,7 @@ using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Extensions;
 using Jellyfin.Plugin.Dlna.Didl;
 using Jellyfin.Plugin.Dlna.Extensions;
+using Jellyfin.Plugin.Dlna.Localization;
 using Jellyfin.Plugin.Dlna.Model;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Entities;
@@ -18,7 +19,6 @@ using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Dto;
-using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Session;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
@@ -44,7 +44,7 @@ public class PlayToSession : ISessionController, IDisposable
     private readonly IUserManager _userManager;
     private readonly IImageProcessor _imageProcessor;
     private readonly IUserDataManager _userDataManager;
-    private readonly ILocalizationManager _localization;
+    private readonly DlnaLocalization _localization;
     private readonly IMediaSourceManager _mediaSourceManager;
     private readonly IMediaEncoder _mediaEncoder;
     private readonly IDeviceDiscovery _deviceDiscovery;
@@ -69,7 +69,7 @@ public class PlayToSession : ISessionController, IDisposable
     /// <param name="accessToken">The access token.</param>
     /// <param name="deviceDiscovery">Instance of the <see cref="IDeviceDiscovery"/> interface.</param>
     /// <param name="userDataManager">Instance of the <see cref="IUserDataManager"/> interface.</param>
-    /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
+    /// <param name="localization">Instance of the <see cref="DlnaLocalization"/> class.</param>
     /// <param name="mediaSourceManager">Instance of the <see cref="IMediaSourceManager"/> interface.</param>
     /// <param name="mediaEncoder">Instance of the <see cref="IMediaEncoder"/> interface.</param>
     /// <param name="device">The <see cref="Device"/>.</param>
@@ -85,7 +85,7 @@ public class PlayToSession : ISessionController, IDisposable
         string? accessToken,
         IDeviceDiscovery deviceDiscovery,
         IUserDataManager userDataManager,
-        ILocalizationManager localization,
+        DlnaLocalization localization,
         IMediaSourceManager mediaSourceManager,
         IMediaEncoder mediaEncoder,
         Device device)

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
@@ -123,6 +123,11 @@ public class PlayToSession : ISessionController, IDisposable
     public bool IsSessionActive => !_disposed;
 
     /// <summary>
+    /// Gets the base URL the renderer is currently controlled through.
+    /// </summary>
+    internal string DeviceBaseUrl => _device.Properties.BaseUrl;
+
+    /// <summary>
     /// Gets a value indicating whether media control is supported.
     /// </summary>
     public bool SupportsMediaControl => IsSessionActive;

--- a/src/Jellyfin.Plugin.Dlna/Profiles/DefaultProfile.cs
+++ b/src/Jellyfin.Plugin.Dlna/Profiles/DefaultProfile.cs
@@ -27,6 +27,8 @@ public class DefaultProfile : DlnaDeviceProfile
         ModelUrl = "https://github.com/jellyfin/jellyfin";
         ManufacturerUrl = "https://github.com/jellyfin/jellyfin";
 
+        EnableMSMediaReceiverRegistrar = true;
+
         AlbumArtPn = "JPEG_SM";
 
         MaxAlbumArtHeight = 480;

--- a/src/Rssdp/SsdpCommunicationsServer.cs
+++ b/src/Rssdp/SsdpCommunicationsServer.cs
@@ -188,12 +188,24 @@ namespace Rssdp.Infrastructure
             catch (OperationCanceledException)
             {
             }
+            catch (SocketException ex) when (IsTransientSendError(ex.SocketErrorCode))
+            {
+                var localIP = (socket.LocalEndPoint as IPEndPoint)?.Address;
+                _logger.LogDebug(ex, "Unable to send socket message from {0} to {1}", localIP?.ToString(), destination.ToString());
+            }
             catch (Exception ex)
             {
                 var localIP = (socket.LocalEndPoint as IPEndPoint)?.Address;
                 _logger.LogError(ex, "Error sending socket message from {0} to {1}", localIP?.ToString(), destination.ToString());
             }
         }
+
+        private static bool IsTransientSendError(SocketError error)
+            => error is SocketError.HostUnreachable
+                or SocketError.HostDown
+                or SocketError.NetworkUnreachable
+                or SocketError.NetworkDown
+                or SocketError.NetworkReset;
 
         private List<Socket> GetSendSockets(IPAddress fromlocalIPAddress, IPEndPoint destination)
         {

--- a/src/Rssdp/SsdpCommunicationsServer.cs
+++ b/src/Rssdp/SsdpCommunicationsServer.cs
@@ -172,7 +172,11 @@ namespace Rssdp.Infrastructure
                 var tasks = sockets.Select(s => SendFromSocket(s, messageData, destination, cancellationToken)).ToArray();
                 await Task.WhenAll(tasks).ConfigureAwait(false);
 
-                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                // Space the repeats out, but do not wait after the last one - nothing follows it.
+                if (i < SsdpConstants.UdpResendCount - 1)
+                {
+                    await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                }
             }
         }
 
@@ -292,7 +296,11 @@ namespace Rssdp.Infrastructure
                     fromLocalIPAddress,
                     cancellationToken).ConfigureAwait(false);
 
-                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                // Space the repeats out, but do not wait after the last one - nothing follows it.
+                if (i < sendCount - 1)
+                {
+                    await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                }
             }
         }
 

--- a/src/Rssdp/SsdpDevicePublisher.cs
+++ b/src/Rssdp/SsdpDevicePublisher.cs
@@ -26,6 +26,11 @@ namespace Rssdp.Infrastructure
         private string _OSVersion;
         private bool _sendOnlyMatchedHost;
 
+        /// <summary>
+        /// The longest a search response is held back for, in milliseconds.
+        /// </summary>
+        private const int MaxSearchResponseDelayMilliseconds = 500;
+
         private bool _SupportPnpRootDevice;
 
         private IList<SsdpRootDevice> _Devices;
@@ -253,8 +258,14 @@ namespace Rssdp.Infrastructure
                 maxWaitInterval = _Random.Next(0, 120);
             }
 
+            // The spec has a device spread its answers across the MX window so that a large network
+            // does not answer a search all at once. A home network has few enough devices for that
+            // to cost only discovery time: with the MX of 5 seconds clients commonly ask for, the
+            // server turns up seconds after everything else. Keep the jitter, cap how far it runs.
+            var maxWaitMilliseconds = Math.Min(maxWaitInterval * 1000, MaxSearchResponseDelayMilliseconds);
+
             // Do not block synchronously as that may tie up a threadpool thread for several seconds.
-            Task.Delay(_Random.Next(16, maxWaitInterval * 1000), cancellationToken).ContinueWith((parentTask) =>
+            Task.Delay(_Random.Next(16, maxWaitMilliseconds), cancellationToken).ContinueWith((parentTask) =>
             {
                 // Copying devices to local array here to avoid threading issues/enumerator exceptions.
                 IEnumerable<SsdpDevice>? devices = null;

--- a/src/Rssdp/SsdpDevicePublisher.cs
+++ b/src/Rssdp/SsdpDevicePublisher.cs
@@ -31,6 +31,11 @@ namespace Rssdp.Infrastructure
         /// </summary>
         private const int MaxSearchResponseDelayMilliseconds = 500;
 
+        /// <summary>
+        /// The longest Dispose waits for the byebye notifications to go out.
+        /// </summary>
+        private static readonly TimeSpan ByeByeNotificationTimeout = TimeSpan.FromSeconds(2);
+
         private bool _SupportPnpRootDevice;
 
         private IList<SsdpRootDevice> _Devices;
@@ -131,7 +136,19 @@ namespace Rssdp.Infrastructure
         /// </remarks>
         /// <param name="device">The <see cref="SsdpDevice"/> instance to add.</param>
         /// <exception cref="ArgumentNullException">Thrown if the <paramref name="device"/> argument is null.</exception>
-        public async Task RemoveDevice(SsdpRootDevice device)
+        public Task RemoveDevice(SsdpRootDevice device)
+        {
+            return RemoveDevice(device, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Removes a device (and it's children) from the list of devices being published by this server, making them undiscoverable.
+        /// </summary>
+        /// <param name="device">The <see cref="SsdpDevice"/> instance to remove.</param>
+        /// <param name="cancellationToken">The token that aborts the byebye notifications.</param>
+        /// <returns>An awaitable <see cref="Task"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the <paramref name="device"/> argument is null.</exception>
+        public async Task RemoveDevice(SsdpRootDevice device, CancellationToken cancellationToken)
         {
             if (device is null)
             {
@@ -151,7 +168,38 @@ namespace Rssdp.Infrastructure
             {
                 WriteTrace("Device Removed", device);
 
-                await SendByeByeNotifications(device, true, CancellationToken.None).ConfigureAwait(false);
+                await SendByeByeNotifications(device, true, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Stops publishing and sends the byebye notifications for every device still published.
+        /// </summary>
+        /// <param name="cancellationToken">The token that aborts the byebye notifications.</param>
+        /// <returns>An awaitable <see cref="Task"/>.</returns>
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            DisposeRebroadcastTimer();
+
+            var commsServer = _CommsServer;
+            if (commsServer is not null)
+            {
+                commsServer.RequestReceived -= this.CommsServer_RequestReceived;
+            }
+
+            SsdpRootDevice[] devices;
+            lock (_Devices)
+            {
+                devices = _Devices.ToArray();
+            }
+
+            try
+            {
+                await Task.WhenAll(Array.ConvertAll(devices, device => RemoveDevice(device, cancellationToken))).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                WriteTrace("Aborted sending byebye notifications");
             }
         }
 
@@ -199,8 +247,18 @@ namespace Rssdp.Infrastructure
                     commsServer.RequestReceived -= this.CommsServer_RequestReceived;
                 }
 
-                var tasks = Devices.ToList().Select(RemoveDevice).ToArray();
-                Task.WaitAll(tasks);
+                try
+                {
+                    var byebye = Task.WhenAll(Devices.ToList().Select(RemoveDevice));
+                    if (!byebye.Wait(ByeByeNotificationTimeout))
+                    {
+                        WriteTrace("Timed out sending byebye notifications");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    WriteTrace("Error sending byebye notifications, exception " + ex.Message);
+                }
 
                 _CommsServer = null;
                 if (commsServer is not null)


### PR DESCRIPTION
* Build server endpoint URIs from their parts and skip unusable loopbacks
* Recreate the session of a renderer that moved to another address
* Count child containers without listing their content
* Apply the search term and browse-by-letter to search results
* List the user views at the DLNA root instead of the raw library folders