### PR TITLE
Fix v12 regressions

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
@@ -247,10 +247,10 @@ public class DidlBuilder
                 switch (item.MediaType)
                 {
                     case MediaType.Audio:
-                        AddAudioResource(writer, item, deviceId, filter, resource);
+                        AddAudioResource(writer, filter, resource);
                         break;
                     case MediaType.Video:
-                        AddVideoResource(writer, item, deviceId, filter, resource);
+                        AddVideoResource(writer, filter, resource);
                         break;
                 }
             }
@@ -309,26 +309,8 @@ public class DidlBuilder
         }
     }
 
-    private void AddVideoResource(XmlWriter writer, BaseItem video, string deviceId, Filter filter, StreamInfo? streamInfo = null)
+    private void AddVideoResource(XmlWriter writer, Filter filter, StreamInfo streamInfo)
     {
-        if (streamInfo is null)
-        {
-            var sources = _mediaSourceManager.GetStaticMediaSources(video, true, _user);
-
-            // DirectStream is served as the source file itself, so a device would be handed a
-            // container its profile rejects while the DIDL advertises the target format. Transcode
-            // instead, the same way PlayTo does.
-            streamInfo = new StreamBuilder(_mediaEncoder, _logger).GetOptimalVideoStream(new MediaOptions
-            {
-                ItemId = video.Id,
-                MediaSources = sources.ToArray(),
-                Profile = _profile,
-                DeviceId = deviceId,
-                MaxBitrate = _profile.MaxStreamingBitrate,
-                EnableDirectStream = false
-            }) ?? throw new InvalidOperationException("No optimal video stream found");
-        }
-
         var targetWidth = streamInfo.TargetWidth;
         var targetHeight = streamInfo.TargetHeight;
         var targetVideoCodec = streamInfo.TargetVideoCodec.Count == 0 ? null : streamInfo.TargetVideoCodec[0];
@@ -662,23 +644,9 @@ public class DidlBuilder
 
     private bool NotNullOrWhiteSpace(string s) => !string.IsNullOrWhiteSpace(s);
 
-    private void AddAudioResource(XmlWriter writer, BaseItem audio, string deviceId, Filter filter, StreamInfo? streamInfo = null)
+    private void AddAudioResource(XmlWriter writer, Filter filter, StreamInfo streamInfo)
     {
         writer.WriteStartElement(string.Empty, "res", NsDidl);
-
-        if (streamInfo is null)
-        {
-            var sources = _mediaSourceManager.GetStaticMediaSources(audio, true, _user);
-
-            streamInfo = new StreamBuilder(_mediaEncoder, _logger).GetOptimalAudioStream(new MediaOptions
-            {
-                ItemId = audio.Id,
-                MediaSources = sources.ToArray(),
-                Profile = _profile,
-                DeviceId = deviceId,
-                EnableDirectStream = false
-            }) ?? throw new InvalidOperationException("No optimal audio stream found");
-        }
 
         var url = NormalizeDlnaMediaUrl(streamInfo.ToDlnaUrl(_serverAddress, _accessToken));
 

--- a/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
+++ b/src/Jellyfin.Plugin.Dlna/Didl/DidlBuilder.cs
@@ -23,11 +23,13 @@ using MediaBrowser.Model.Drawing;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Net;
 using Microsoft.Extensions.Logging;
+using DlnaProfileType = MediaBrowser.Model.Dlna.DlnaProfileType;
 using Episode = MediaBrowser.Controller.Entities.TV.Episode;
 using Genre = MediaBrowser.Controller.Entities.Genre;
 using MediaOptions = MediaBrowser.Model.Dlna.MediaOptions;
 using Movie = MediaBrowser.Controller.Entities.Movies.Movie;
 using MusicAlbum = MediaBrowser.Controller.Entities.Audio.MusicAlbum;
+using PlayMethod = MediaBrowser.Model.Session.PlayMethod;
 using Season = MediaBrowser.Controller.Entities.TV.Season;
 using Series = MediaBrowser.Controller.Entities.TV.Series;
 using StreamBuilder = MediaBrowser.Model.Dlna.StreamBuilder;
@@ -283,20 +285,33 @@ public class DidlBuilder
                 ItemId = item.Id,
                 MediaSources = sources.ToArray(),
                 Profile = _profile,
-                DeviceId = deviceId,
-                EnableDirectStream = false
+                DeviceId = deviceId
             };
 
             var builder = new StreamBuilder(_mediaEncoder, _logger);
+            var isAudio = item.MediaType == MediaType.Audio;
 
-            if (item.MediaType == MediaType.Audio)
+            if (!isAudio)
             {
-                return builder.GetOptimalAudioStream(options);
+                options.MaxBitrate = _profile.MaxStreamingBitrate;
             }
 
-            options.MaxBitrate = _profile.MaxStreamingBitrate;
+            var type = isAudio ? DlnaProfileType.Audio : DlnaProfileType.Video;
+            var resolved = isAudio ? builder.GetOptimalAudioStream(options) : builder.GetOptimalVideoStream(options);
 
-            return builder.GetOptimalVideoStream(options);
+            // DirectStream is served as the source file itself. The stream builder still offers it
+            // for a container the profile rejects, which hands the device that container while the
+            // DIDL advertises the one the profile does accept, so transcode in that case. Where the
+            // container is accepted the file is what the device asked for, and serving it is what
+            // lets the device read the subtitles and the extra audio tracks embedded in it.
+            if (resolved?.PlayMethod == PlayMethod.DirectStream && !SupportsSourceContainer(resolved, type))
+            {
+                options.EnableDirectStream = false;
+
+                resolved = isAudio ? builder.GetOptimalAudioStream(options) : builder.GetOptimalVideoStream(options);
+            }
+
+            return resolved;
         }
         catch (Exception ex)
         {
@@ -307,6 +322,18 @@ public class DidlBuilder
 
             return null;
         }
+    }
+
+    private bool SupportsSourceContainer(StreamInfo streamInfo, DlnaProfileType type)
+    {
+        var container = streamInfo.MediaSource?.Container;
+
+        if (string.IsNullOrEmpty(container))
+        {
+            return false;
+        }
+
+        return _profile.DirectPlayProfiles.Any(i => i.Type == type && i.SupportsContainer(container));
     }
 
     private void AddVideoResource(XmlWriter writer, Filter filter, StreamInfo streamInfo)

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
@@ -26,9 +26,12 @@ public class Device : IDisposable
 
     /// <summary>
     /// How long a renderer is given to come up after it was handed a new track before what it
-    /// reports is taken at face value.
+    /// reports is taken at face value. A speaker that has to open and buffer a stream the server
+    /// is still transcoding sits in STOPPED for a while, so the window is generous. It is closed
+    /// again as soon as the renderer reports anything other than STOPPED, which keeps a stop the
+    /// listener triggers themselves from being held back by it.
     /// </summary>
-    private static readonly TimeSpan _transportChangeGrace = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan _transportChangeGrace = TimeSpan.FromSeconds(30);
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger _logger;
@@ -40,7 +43,7 @@ public class Device : IDisposable
     private bool _volumeRefreshActive;
     private int _connectFailureCount;
     private int _transportChanges;
-    private DateTime _transportChangedAt = DateTime.MinValue;
+    private long _transportChangedAtTicks;
     private bool _disposed;
 
     /// <summary>
@@ -220,6 +223,16 @@ public class Device : IDisposable
             _timer?.Change(Timeout.Infinite, Timeout.Infinite);
         }
     }
+
+    private bool IsAwaitingPlayback()
+    {
+        var changedAt = Interlocked.Read(ref _transportChangedAtTicks);
+
+        return changedAt != 0 && DateTime.UtcNow - new DateTime(changedAt, DateTimeKind.Utc) < _transportChangeGrace;
+    }
+
+    private void CloseTransportChangeGrace()
+        => Interlocked.Exchange(ref _transportChangedAtTicks, 0);
 
     /// <summary>
     /// Lowers the volume.
@@ -478,7 +491,7 @@ public class Device : IDisposable
         }
         finally
         {
-            _transportChangedAt = DateTime.UtcNow;
+            Interlocked.Exchange(ref _transportChangedAtTicks, DateTime.UtcNow.Ticks);
             Interlocked.Decrement(ref _transportChanges);
         }
 
@@ -604,7 +617,7 @@ public class Device : IDisposable
         await SetStop(avCommands, cancellationToken).ConfigureAwait(false);
 
         // Stopping is meant to be observed right away, it is not a renderer on its way to a new track
-        _transportChangedAt = DateTime.MinValue;
+        CloseTransportChangeGrace();
 
         RestartTimer(true);
     }
@@ -674,18 +687,24 @@ public class Device : IDisposable
                 return;
             }
 
+            // A renderer that was just handed a new track can still report STOPPED, or answer
+            // nothing at all, while it opens the stream. Taking that as idle would report the
+            // previous track as stopped and park the timer, so the playback that follows would
+            // never be reported at all.
+            if (transportState is null or TransportState.STOPPED && IsAwaitingPlayback())
+            {
+                _connectFailureCount = 0;
+                RestartTimerIn(TransportChangeTimerInterval);
+
+                return;
+            }
+
             if (transportState.HasValue)
             {
-                // A renderer that was just handed a new track can still report STOPPED while it opens
-                // the stream. Taking that as idle would report the previous track as stopped and park
-                // the timer, so the playback that follows would never be reported at all.
-                if (transportState.Value == TransportState.STOPPED
-                    && DateTime.UtcNow - _transportChangedAt < _transportChangeGrace)
+                // The renderer is up, so anything it reports from here on is what it is really doing
+                if (transportState.Value != TransportState.STOPPED)
                 {
-                    _connectFailureCount = 0;
-                    RestartTimerIn(TransportChangeTimerInterval);
-
-                    return;
+                    CloseTransportChangeGrace();
                 }
 
                 // If we're not playing anything no need to get additional data


### PR DESCRIPTION
v12 added a Stop before `SetAVTransportURI`, so the 100 ms poll that follows reliably catches the renderer in `STOPPED`, reports the track stopped, and parks the timer at `Timeout.Infinite` while controls never appear though playback continues.
  - Transport-change grace 5 s → 30 s (a speaker buffering a transcode sits in STOPPED past 5 s).
  - Grace now also covers `transportState == null`.
  - Grace closes on the first non-STOPPED reading, so a listener-triggered stop is still reported at once.
  - `_transportChangedAt` → `_transportChangedAtTicks` with Interlocked

We also set `EnableDirectStream = false` blanket. Since core's `DirectStreamReasons` covers `AudioCodecNotSupported`, mkv/h264/eac3 files that used to be served as-is (embedded subs readable by the TV) now take the ts transcode, where embed is impossible and delivery drops to External.
  - `ResolveStreamInfo` runs with `DirectStream` enabled and only re-resolves with it disabled when the resulting DirectStream's source container isn't covered by a `DirectPlayProfile`.


Fixes #241 
Fixes #238 
