### PR TITLE
Fix track changes that renderers ignore or overrun

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/Device.cs
@@ -24,13 +24,9 @@ public class Device : IDisposable
     private const int ActiveTimerInterval = 10000;
     private const int TransportChangeTimerInterval = 500;
 
-    /// <summary>
-    /// How long a renderer is given to come up after it was handed a new track before what it
-    /// reports is taken at face value. A speaker that has to open and buffer a stream the server
-    /// is still transcoding sits in STOPPED for a while, so the window is generous. It is closed
-    /// again as soon as the renderer reports anything other than STOPPED, which keeps a stop the
-    /// listener triggers themselves from being held back by it.
-    /// </summary>
+    private static readonly TimeSpan _stopPollInterval = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan _stopTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan _transportSettleTime = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan _transportChangeGrace = TimeSpan.FromSeconds(30);
 
     private readonly IHttpClientFactory _httpClientFactory;
@@ -454,18 +450,16 @@ public class Device : IDisposable
 
         try
         {
-            // AVTransport:1 section 2.4.2 defines SetAVTransportURI for the STOPPED and NO_MEDIA_PRESENT states only.
-            // A renderer that is still playing, e.g. because it was stopped from its own remote, answers every
-            // following request with 705 (Transport is locked) until it is stopped.
-            try
-            {
-                await SetStop(avCommands!, cancellationToken).ConfigureAwait(false); // null checked above
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                // Stopping a transport that is already idle is a no-op that some devices fault on
-                _logger.LogDebug(ex, "{Name} - Stop before SetAVTransportURI failed", Properties.Name);
-            }
+            // AVTransport:1 section 2.4.2 defines SetAVTransportURI for the STOPPED and NO_MEDIA_PRESENT states
+            // only. A renderer that is still playing, e.g. because it was stopped from its own remote, answers
+            // every following request with 705 (Transport is locked) until it is stopped. Others take the
+            // request and keep playing what they had, so the transport has to have come to a stop first.
+            await StopForTransportChange(avCommands!, cancellationToken).ConfigureAwait(false); // null checked above
+
+            // The renderer still holds the track that was queued behind the one it was playing. Renderers that
+            // move to their queued track when the transport starts would land on that instead of the track
+            // handed over here, a track further on than the one that was asked for.
+            await ClearNextAvTransport(avCommands!, service, cancellationToken).ConfigureAwait(false); // null checked above
 
             await new DlnaHttpClient(_logger, _httpClientFactory)
                 .SendCommandAsync(
@@ -488,6 +482,10 @@ public class Device : IDisposable
                 // Some devices will throw an error if you tell it to play when it's already playing
                 // Others won't
             }
+
+            // Hold the renderer while it starts the track, so nothing reaches it that it could take
+            // as the track to play instead. A poll cannot get past _transportChanges either.
+            await Task.Delay(_transportSettleTime, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -537,6 +535,90 @@ public class Device : IDisposable
             .ConfigureAwait(false);
 
         return true;
+    }
+
+    private async Task ClearNextAvTransport(TransportCommands avCommands, DeviceService service, CancellationToken cancellationToken)
+    {
+        var command = avCommands.ServiceActions.FirstOrDefault(c => string.Equals(c.Name, "SetNextAVTransportURI", StringComparison.OrdinalIgnoreCase));
+        if (command is null)
+        {
+            return;
+        }
+
+        // AVTransport:1 section 2.4.3: an empty NextURI is what tells a renderer to forget what it has queued.
+        var dictionary = new Dictionary<string, string>
+        {
+            { "NextURI", string.Empty },
+            { "NextURIMetaData", string.Empty }
+        };
+
+        try
+        {
+            await new DlnaHttpClient(_logger, _httpClientFactory)
+                .SendCommandAsync(
+                    NormalizeUrl(service.ControlUrl),
+                    service,
+                    command.Name,
+                    avCommands.BuildPost(command, service.ServiceType, string.Empty, dictionary),
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A renderer that refuses an empty NextURI keeps what it had queued, which is what it did before
+            _logger.LogDebug(ex, "{Name} - Clearing the queued next track failed", Properties.Name);
+        }
+    }
+
+    private async Task StopForTransportChange(TransportCommands avCommands, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await SetStop(avCommands, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Stopping a transport that is already idle is a no-op that some devices fault on
+            _logger.LogDebug(ex, "{Name} - Stop before SetAVTransportURI failed", Properties.Name);
+        }
+
+        var waited = TimeSpan.Zero;
+        while (true)
+        {
+            TransportState? state;
+            try
+            {
+                state = await GetTransportInfo(avCommands, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Without an answer there is nothing to wait for, so hand the track over
+                _logger.LogDebug(ex, "{Name} - Reading the transport state after Stop failed", Properties.Name);
+
+                return;
+            }
+
+            // No answer, or a state that is not modelled here such as the NO_MEDIA_PRESENT of an empty
+            // transport, leaves nothing to wait for: the renderer is as ready for a new track as a stopped one.
+            if (state is not (TransportState.PLAYING or TransportState.TRANSITIONING))
+            {
+                return;
+            }
+
+            if (waited >= _stopTimeout)
+            {
+                _logger.LogWarning(
+                    "{Name} - Transport still reports {State} {Seconds}s after it was stopped, handing over the track regardless",
+                    Properties.Name,
+                    state,
+                    _stopTimeout.TotalSeconds);
+
+                return;
+            }
+
+            await Task.Delay(_stopPollInterval, cancellationToken).ConfigureAwait(false);
+            waited += _stopPollInterval;
+        }
     }
 
     private static string CreateDidlMeta(string value)

--- a/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
+++ b/src/Jellyfin.Plugin.Dlna/PlayTo/PlayToSession.cs
@@ -56,6 +56,7 @@ public class PlayToSession : ISessionController, IDisposable
     private Device _device;
     private int _currentPlaylistIndex;
     private int _nextTrackIndex = -1;
+    private string? _nextTrackAnnouncedFor;
     private bool _disposed;
 
     /// <summary>
@@ -174,6 +175,39 @@ public class PlayToSession : ISessionController, IDisposable
         }
     }
 
+    private async Task SyncWithReportedMedia(StreamParams info, string mediaUrl, CancellationToken cancellationToken)
+    {
+        var currentIndex = _playlist.FindIndex(item => item.StreamInfo.ItemId.Equals(info.ItemId));
+        if (currentIndex < 0)
+        {
+            return;
+        }
+
+        _currentPlaylistIndex = currentIndex;
+
+        // AVTransport:1 section 2.4.3 defines SetNextAVTransportURI for a renderer that holds media, and one
+        // that is still on its way to a track can take what it has queued as the track to play right now,
+        // landing a track further on than the one it was handed. So the follow-up is announced only once the
+        // renderer reports that it is playing the track it was given, and only once for that track.
+        if (!_device.IsPlaying || string.Equals(_nextTrackAnnouncedFor, mediaUrl, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Marked before announcing: the device timer polls again while the announcement is still on its way
+        _nextTrackAnnouncedFor = mediaUrl;
+
+        await SendNextTrackMessage(currentIndex, cancellationToken).ConfigureAwait(false);
+    }
+
+    private Task SetAvTransport(PlaylistItem item, CancellationToken cancellationToken)
+    {
+        _nextTrackIndex = -1;
+        _nextTrackAnnouncedFor = null;
+
+        return _device.SetAvTransport(item.StreamUrl, GetDlnaHeaders(item), item.Didl, cancellationToken);
+    }
+
     private async void OnDeviceUnavailable()
     {
         try
@@ -229,14 +263,7 @@ public class PlayToSession : ISessionController, IDisposable
 
             await _sessionManager.OnPlaybackStart(newItemProgress).ConfigureAwait(false);
 
-            // Send a message to the DLNA device to notify what is the next track in the playlist.
-            var currentItemIndex = _playlist.FindIndex(item => item.StreamInfo.ItemId.Equals(streamInfo.ItemId));
-            if (currentItemIndex >= 0)
-            {
-                _currentPlaylistIndex = currentItemIndex;
-            }
-
-            await SendNextTrackMessage(currentItemIndex, CancellationToken.None).ConfigureAwait(false);
+            await SyncWithReportedMedia(streamInfo, e.NewMediaInfo.Url, CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -343,6 +370,8 @@ public class PlayToSession : ISessionController, IDisposable
                 var progress = GetProgressInfo(info);
 
                 await _sessionManager.OnPlaybackStart(progress).ConfigureAwait(false);
+
+                await SyncWithReportedMedia(info, e.MediaInfo.Url, CancellationToken.None).ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -374,6 +403,10 @@ public class PlayToSession : ISessionController, IDisposable
                 var progress = GetProgressInfo(info);
 
                 await _sessionManager.OnPlaybackProgress(progress).ConfigureAwait(false);
+
+                // A renderer that was handed a track while it was on its way to another one may have been
+                // in no state to take the follow-up, so keep offering it for as long as it plays the track.
+                await SyncWithReportedMedia(info, mediaUrl, CancellationToken.None).ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -513,7 +546,13 @@ public class PlayToSession : ISessionController, IDisposable
                 _playlist.Count);
 
             // The item following the one that is playing may have changed, so tell the device about it again
-            return SendNextTrackMessage(_currentPlaylistIndex, cancellationToken);
+            _nextTrackAnnouncedFor = null;
+
+            var media = _device.CurrentMediaInfo;
+
+            return string.IsNullOrEmpty(media?.Url)
+                ? Task.CompletedTask
+                : SyncWithReportedMedia(StreamParams.ParseFromUrl(media.Url, _libraryManager, _mediaSourceManager), media.Url, cancellationToken);
         }
 
         return PlayItems(playlist, cancellationToken);
@@ -564,11 +603,7 @@ public class PlayToSession : ISessionController, IDisposable
                     : _userManager.GetUserById(_session.UserId);
                 var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, info.AudioStreamIndex, info.SubtitleStreamIndex, GetProfile());
 
-                await _device.SetAvTransport(newItem.StreamUrl, GetDlnaHeaders(newItem), newItem.Didl, CancellationToken.None).ConfigureAwait(false);
-
-                // Send a message to the DLNA device to notify what is the next track in the play list.
-                var newItemIndex = _playlist.FindIndex(item => item.StreamUrl == newItem.StreamUrl);
-                await SendNextTrackMessage(newItemIndex, CancellationToken.None).ConfigureAwait(false);
+                await SetAvTransport(newItem, CancellationToken.None).ConfigureAwait(false);
 
                 return;
             }
@@ -761,6 +796,7 @@ public class PlayToSession : ISessionController, IDisposable
     {
         _playlist.Clear();
         _nextTrackIndex = -1;
+        _nextTrackAnnouncedFor = null;
     }
 
     private async Task SetPlaylistIndex(int index, CancellationToken cancellationToken = default)
@@ -775,10 +811,7 @@ public class PlayToSession : ISessionController, IDisposable
         _currentPlaylistIndex = index;
         var currentitem = _playlist[index];
 
-        await _device.SetAvTransport(currentitem.StreamUrl, GetDlnaHeaders(currentitem), currentitem.Didl, cancellationToken).ConfigureAwait(false);
-
-        // Send a message to the DLNA device to notify what is the next track in the play list.
-        await SendNextTrackMessage(index, cancellationToken).ConfigureAwait(false);
+        await SetAvTransport(currentitem, cancellationToken).ConfigureAwait(false);
 
         var streamInfo = currentitem.StreamInfo;
         if (streamInfo.StartPositionTicks > 0 && EnableClientSideSeek(streamInfo))
@@ -891,11 +924,7 @@ public class PlayToSession : ISessionController, IDisposable
                     : _userManager.GetUserById(_session.UserId);
                 var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, newIndex, info.SubtitleStreamIndex, GetProfile());
 
-                await _device.SetAvTransport(newItem.StreamUrl, GetDlnaHeaders(newItem), newItem.Didl, CancellationToken.None).ConfigureAwait(false);
-
-                // Send a message to the DLNA device to notify what is the next track in the play list.
-                var newItemIndex = _playlist.FindIndex(item => item.StreamUrl == newItem.StreamUrl);
-                await SendNextTrackMessage(newItemIndex, CancellationToken.None).ConfigureAwait(false);
+                await SetAvTransport(newItem, CancellationToken.None).ConfigureAwait(false);
 
                 if (EnableClientSideSeek(newItem.StreamInfo))
                 {
@@ -922,11 +951,7 @@ public class PlayToSession : ISessionController, IDisposable
                     : _userManager.GetUserById(_session.UserId);
                 var newItem = CreatePlaylistItem(info.Item, user, newPosition, info.MediaSourceId, info.AudioStreamIndex, newIndex, GetProfile());
 
-                await _device.SetAvTransport(newItem.StreamUrl, GetDlnaHeaders(newItem), newItem.Didl, CancellationToken.None).ConfigureAwait(false);
-
-                // Send a message to the DLNA device to notify what is the next track in the play list.
-                var newItemIndex = _playlist.FindIndex(item => item.StreamUrl == newItem.StreamUrl);
-                await SendNextTrackMessage(newItemIndex, CancellationToken.None).ConfigureAwait(false);
+                await SetAvTransport(newItem, CancellationToken.None).ConfigureAwait(false);
 
                 if (EnableClientSideSeek(newItem.StreamInfo) && newPosition > 0)
                 {


### PR DESCRIPTION
A track change was `Stop` → `SetAVTransportURI` → 50ms → `Play`, with the next track announced right after. Three things go wrong on real renderers:

  - **Stop was not waited for.** The action is answered when it is accepted, not when the transport has stopped, and a renderer that is still playing drops the `SetAVTransportURI` that follows (AVTransport:1 §2.4.2 defines it for STOPPED
    and NO_MEDIA_PRESENT only). `Play` then carries on with the old track, which is the Marantz NR1609 / HEOS report: the track never changes.
  - **The queued next track was never cleared.** The renderer still held track N+1 from when track N was loaded, so one that moves to its queued track at the transition lands a track further on: the upmpdcli 0 → 1 → 3 report.
  - **The follow-up was announced too early**, while the renderer was still starting the new track, where some take it as the track to play now.

**Changes**
`Device`:
  - `StopForTransportChange` stops and then polls `GetTransportInfo` until the transport no longer reports PLAYING or TRANSITIONING, capped at 3s.
  - `ClearNextAvTransport` sends an empty `NextURI` (§2.4.3) before the handover, so nothing the renderer had queued survives it.
  - A settle window after `Play`, during which polling is already held off, so no follow-up can reach the renderer while it is starting the track.

`PlayToSession`: the next track is announced only once the renderer reports it is playing, once per track, off the poll that reports it. That also retries for a renderer that was in no state to take it, and fixes the audio and subtitle stream paths, whose lookup by stream URL never matched the playlist.

**Issues**
Fixes #244